### PR TITLE
fix #11

### DIFF
--- a/src/parse/command.rs
+++ b/src/parse/command.rs
@@ -495,6 +495,7 @@ fn fetch_att(input: &[u8]) -> IResult<&[u8], DataItem> {
         value(DataItem::Rfc822Header, tag_no_case(b"RFC822.HEADER")),
         value(DataItem::Rfc822Size, tag_no_case(b"RFC822.SIZE")),
         value(DataItem::Rfc822Text, tag_no_case(b"RFC822.TEXT")),
+        value(DataItem::Rfc822, tag_no_case(b"RFC822")),
     ))(input)
 }
 


### PR DESCRIPTION
Seems to easy to be correct. Variant was already in place, so was serialization.
Tested with example and my own project and everything seems to work.
Is it ok for imap_codec::types::response::DataItemResponse::Rfc822(NString) to have NString or should it be imap_codec::types::body::BodyStructure like imap_codec::types::response::DataItemResponse::Body(BodyStructure) is?