### PR TITLE
Exposed a bunch of parse functions to the public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [features]
 default = []
 serdex  = ["serde", "chrono/serde"]
+nomx = []
 
 [dependencies]
 arbitrary = { version = "1", optional = true, features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ use codec::Encode;
 pub mod arbitrary;
 pub mod codec;
 pub mod parse;
+#[cfg(feature = "nomx")]
+pub mod rfc3501;
 pub mod state;
 pub mod types;
 pub mod utils;

--- a/src/parse/address.rs
+++ b/src/parse/address.rs
@@ -14,7 +14,7 @@ use crate::{
 ///               addr-adl SP
 ///               addr-mailbox SP
 ///               addr-host ")"
-pub(crate) fn address(input: &[u8]) -> IResult<&[u8], Address> {
+pub fn address(input: &[u8]) -> IResult<&[u8], Address> {
     let mut parser = delimited(
         tag(b"("),
         tuple((addr_name, SP, addr_adl, SP, addr_mailbox, SP, addr_host)),

--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -26,7 +26,7 @@ use crate::{
 ///
 /// Note: This parser is recursively defined. Thus, in order to not overflow the stack,
 /// it is needed to limit how may recursions are allowed. (8 should suffice).
-pub(crate) fn body(remaining_recursions: usize) -> impl Fn(&[u8]) -> IResult<&[u8], BodyStructure> {
+pub fn body(remaining_recursions: usize) -> impl Fn(&[u8]) -> IResult<&[u8], BodyStructure> {
     move |input: &[u8]| body_limited(input, remaining_recursions)
 }
 

--- a/src/parse/datetime.rs
+++ b/src/parse/datetime.rs
@@ -13,7 +13,7 @@ use nom::{
 use crate::types::datetime::{MyDateTime, MyNaiveDate};
 
 /// date = date-text / DQUOTE date-text DQUOTE
-pub(crate) fn date(input: &[u8]) -> IResult<&[u8], Option<MyNaiveDate>> {
+pub fn date(input: &[u8]) -> IResult<&[u8], Option<MyNaiveDate>> {
     alt((date_text, delimited(DQUOTE, date_text, DQUOTE)))(input)
 }
 
@@ -76,7 +76,7 @@ fn time(input: &[u8]) -> IResult<&[u8], Option<NaiveTime>> {
 }
 
 /// date-time = DQUOTE date-day-fixed "-" date-month "-" date-year SP time SP zone DQUOTE
-pub(crate) fn date_time(input: &[u8]) -> IResult<&[u8], MyDateTime> {
+pub fn date_time(input: &[u8]) -> IResult<&[u8], MyDateTime> {
     let mut parser = delimited(
         DQUOTE,
         tuple((

--- a/src/parse/envelope.rs
+++ b/src/parse/envelope.rs
@@ -28,7 +28,7 @@ use crate::{
 ///            env-in-reply-to SP
 ///            env-message-id
 ///            ")"
-pub(crate) fn envelope(input: &[u8]) -> IResult<&[u8], Envelope> {
+pub fn envelope(input: &[u8]) -> IResult<&[u8], Envelope> {
     let mut parser = delimited(
         tag(b"("),
         tuple((

--- a/src/parse/fetch_attributes.rs
+++ b/src/parse/fetch_attributes.rs
@@ -33,7 +33,7 @@ use crate::{
 ///             "UID" /
 ///             "BODY" section ["<" number "." nz-number ">"] /
 ///             "BODY.PEEK" section ["<" number "." nz-number ">"]
-pub(crate) fn fetch_att(input: &[u8]) -> IResult<&[u8], FetchAttribute> {
+pub fn fetch_att(input: &[u8]) -> IResult<&[u8], FetchAttribute> {
     alt((
         value(FetchAttribute::Envelope, tag_no_case(b"ENVELOPE")),
         value(FetchAttribute::Flags, tag_no_case(b"FLAGS")),
@@ -83,7 +83,7 @@ pub(crate) fn fetch_att(input: &[u8]) -> IResult<&[u8], FetchAttribute> {
 /// msg-att = "("
 ///           (msg-att-dynamic / msg-att-static) *(SP (msg-att-dynamic / msg-att-static))
 ///           ")"
-pub(crate) fn msg_att(input: &[u8]) -> IResult<&[u8], NonEmptyVec<FetchAttributeValue>> {
+pub fn msg_att(input: &[u8]) -> IResult<&[u8], NonEmptyVec<FetchAttributeValue>> {
     delimited(
         tag(b"("),
         map(

--- a/src/parse/flag.rs
+++ b/src/parse/flag.rs
@@ -21,7 +21,7 @@ use crate::{
 ///        flag-extension
 ///
 /// Note: Does not include "\Recent"
-pub(crate) fn flag(input: &[u8]) -> IResult<&[u8], Flag> {
+pub fn flag(input: &[u8]) -> IResult<&[u8], Flag> {
     alt((
         value(Flag::Answered, tag_no_case(b"\\Answered")),
         value(Flag::Flagged, tag_no_case(b"\\Flagged")),
@@ -34,12 +34,12 @@ pub(crate) fn flag(input: &[u8]) -> IResult<&[u8], Flag> {
 }
 
 /// flag-fetch = flag / "\Recent"
-pub(crate) fn flag_fetch(input: &[u8]) -> IResult<&[u8], Flag> {
+pub fn flag_fetch(input: &[u8]) -> IResult<&[u8], Flag> {
     alt((flag, value(Flag::Recent, tag_no_case(b"\\Recent"))))(input)
 }
 
 /// flag-perm = flag / "\*"
-pub(crate) fn flag_perm(input: &[u8]) -> IResult<&[u8], Flag> {
+pub fn flag_perm(input: &[u8]) -> IResult<&[u8], Flag> {
     alt((flag, value(Flag::Permanent, tag(b"\\*"))))(input)
 }
 
@@ -50,7 +50,7 @@ fn flag_keyword(input: &[u8]) -> IResult<&[u8], Flag> {
 }
 
 /// flag-list = "(" [flag *(SP flag)] ")"
-pub(crate) fn flag_list(input: &[u8]) -> IResult<&[u8], Vec<Flag>> {
+pub fn flag_list(input: &[u8]) -> IResult<&[u8], Vec<Flag>> {
     delimited(tag(b"("), separated_list0(SP, flag), tag(b")"))(input)
 }
 
@@ -59,7 +59,7 @@ pub(crate) fn flag_list(input: &[u8]) -> IResult<&[u8], Vec<Flag>> {
 ///
 /// Note: ABNF enforces that sflag is not used more than once.
 ///       We parse any flag and check for multiple occurrences of sflag later.
-pub(crate) fn mbx_list_flags(input: &[u8]) -> IResult<&[u8], Vec<FlagNameAttribute>> {
+pub fn mbx_list_flags(input: &[u8]) -> IResult<&[u8], Vec<FlagNameAttribute>> {
     let (remaining, flags) = separated_list1(SP, alt((mbx_list_sflag, mbx_list_oflag)))(input)?;
 
     let sflag_count = flags

--- a/src/parse/mailbox.rs
+++ b/src/parse/mailbox.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 /// list-mailbox = 1*list-char / string
-pub(crate) fn list_mailbox(input: &[u8]) -> IResult<&[u8], ListMailbox> {
+pub fn list_mailbox(input: &[u8]) -> IResult<&[u8], ListMailbox> {
     alt((
         map(take_while1(is_list_char), |bytes: &[u8]| {
             // Note: this is safe, because is_list_char enforces
@@ -42,12 +42,12 @@ pub(crate) fn list_mailbox(input: &[u8]) -> IResult<&[u8], ListMailbox> {
 }
 
 /// list-char = ATOM-CHAR / list-wildcards / resp-specials
-pub(crate) fn is_list_char(i: u8) -> bool {
+pub fn is_list_char(i: u8) -> bool {
     is_atom_char(i) || is_list_wildcards(i) || is_resp_specials(i)
 }
 
 /// list-wildcards = "%" / "*"
-pub(crate) fn is_list_wildcards(i: u8) -> bool {
+pub fn is_list_wildcards(i: u8) -> bool {
     i == b'%' || i == b'*'
 }
 
@@ -60,7 +60,7 @@ pub(crate) fn is_list_wildcards(i: u8) -> bool {
 /// Refer to section 5.1 for further semantic details of mailbox names.
 ///
 /// mailbox = "INBOX" / astring
-pub(crate) fn mailbox(input: &[u8]) -> IResult<&[u8], Mailbox> {
+pub fn mailbox(input: &[u8]) -> IResult<&[u8], Mailbox> {
     map(astring, |astr| {
         match MailboxOther::try_from(astr.to_owned()) {
             Ok(other) => Mailbox::Other(other),
@@ -76,7 +76,7 @@ pub(crate) fn mailbox(input: &[u8]) -> IResult<&[u8], Mailbox> {
 ///                "STATUS" SP mailbox SP "(" [status-att-list] ")" /
 ///                number SP "EXISTS" /
 ///                number SP "RECENT"
-pub(crate) fn mailbox_data(input: &[u8]) -> IResult<&[u8], Data> {
+pub fn mailbox_data(input: &[u8]) -> IResult<&[u8], Data> {
     alt((
         map(
             tuple((tag_no_case(b"FLAGS"), SP, flag_list)),

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -24,7 +24,7 @@ pub mod status_attributes;
 /// auth-type = atom
 ///
 /// Note: Defined by [SASL]
-pub(crate) fn auth_type(input: &[u8]) -> IResult<&[u8], AuthMechanism> {
+pub fn auth_type(input: &[u8]) -> IResult<&[u8], AuthMechanism> {
     let (rem, mechanism) = atom(input)?;
 
     Ok((rem, mechanism.to_owned().into()))

--- a/src/parse/section.rs
+++ b/src/parse/section.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// section = "[" [section-spec] "]"
-pub(crate) fn section(input: &[u8]) -> IResult<&[u8], Option<Section>> {
+pub fn section(input: &[u8]) -> IResult<&[u8], Option<Section>> {
     delimited(tag(b"["), opt(section_spec), tag(b"]"))(input)
 }
 

--- a/src/parse/sequence.rs
+++ b/src/parse/sequence.rs
@@ -32,7 +32,7 @@ use crate::{
 /// sequence-set = (seq-number / seq-range) *("," (seq-number / seq-range))
 ///
 /// TODO: Why the errata?
-pub(crate) fn sequence_set(input: &[u8]) -> IResult<&[u8], SequenceSet> {
+pub fn sequence_set(input: &[u8]) -> IResult<&[u8], SequenceSet> {
     map(
         separated_list1(
             tag(b","),

--- a/src/parse/status_attributes.rs
+++ b/src/parse/status_attributes.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// status-att = "MESSAGES" / "RECENT" / "UIDNEXT" / "UIDVALIDITY" / "UNSEEN"
-pub(crate) fn status_att(input: &[u8]) -> IResult<&[u8], StatusAttribute> {
+pub fn status_att(input: &[u8]) -> IResult<&[u8], StatusAttribute> {
     alt((
         value(StatusAttribute::Messages, tag_no_case(b"MESSAGES")),
         value(StatusAttribute::Recent, tag_no_case(b"RECENT")),
@@ -26,7 +26,7 @@ pub(crate) fn status_att(input: &[u8]) -> IResult<&[u8], StatusAttribute> {
 
 /// ; errata id: 261
 /// status-att-list = status-att-val *(SP status-att-val)
-pub(crate) fn status_att_list(input: &[u8]) -> IResult<&[u8], Vec<StatusAttributeValue>> {
+pub fn status_att_list(input: &[u8]) -> IResult<&[u8], Vec<StatusAttributeValue>> {
     separated_list1(SP, status_att_val)(input)
 }
 

--- a/src/rfc3501.rs
+++ b/src/rfc3501.rs
@@ -1,0 +1,28 @@
+#[doc(inline)]
+pub use crate::parse::address::address;
+#[doc(inline)]
+pub use crate::parse::body::body;
+#[doc(inline)]
+pub use crate::parse::command::{authenticate_data, command, compress, idle_done};
+#[doc(inline)]
+pub use crate::parse::datetime::{date, date_time};
+#[doc(inline)]
+pub use crate::parse::envelope::envelope;
+#[doc(inline)]
+pub use crate::parse::fetch_attributes::{fetch_att, msg_att};
+#[doc(inline)]
+pub use crate::parse::flag::{flag, flag_fetch, flag_list, flag_perm, mbx_list_flags};
+#[doc(inline)]
+pub use crate::parse::mailbox::{
+    is_list_char, is_list_wildcards, list_mailbox, mailbox, mailbox_data,
+};
+#[doc(inline)]
+pub use crate::parse::response::{capability, greeting, response};
+#[doc(inline)]
+pub use crate::parse::section::section;
+#[doc(inline)]
+pub use crate::parse::sequence::sequence_set;
+#[doc(inline)]
+pub use crate::parse::status_attributes::{status_att, status_att_list};
+#[doc(inline)]
+pub use crate::parse::{algorithm, auth_type};


### PR DESCRIPTION
For issue #15 
Exposed some parsing functions from `mod parse`.
Left `crate::parse::core` untouched. Not sure what is useful in `core` for most users.
Also couldn't export some functions that used non-public types, such as `AStringRef`.