### PR TITLE
Update arbitrary to prevent stack overflow.

### DIFF
--- a/imap-types/Cargo.toml
+++ b/imap-types/Cargo.toml
@@ -27,7 +27,7 @@ ext_compress = []
 # ext_saslir = []                           # TODO
 
 [dependencies]
-arbitrary = { version = "1", optional = true, features = ["derive"] }
+arbitrary = { version = "1.1.1", optional = true, features = ["derive"] }
 base64 = "0.13"
 bounded-static = { version = "0.4", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
The newest release fixes the stack overflow that
may occur for recursive types which derive `Arbitrary`.
The type `BodyStructure` was affected by this.

Fixes #61