### PR TITLE
Add RFC2087 QUOTA extension to imap-types.

### DIFF
--- a/imap-types/Cargo.toml
+++ b/imap-types/Cargo.toml
@@ -20,7 +20,7 @@ starttls = []
 ext_idle = []
 ext_enable = []
 ext_compress = []
-
+ext_quota = []
 # ext_mailbox_referrals = ["ext_referrals"] # TODO
 # ext_login_referrals = ["ext_referrals"]   # TODO
 # ext_referrals = []                        # TODO

--- a/imap-types/fuzz/Cargo.toml
+++ b/imap-types/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ cargo-fuzz = true
 ext_idle = ["imap-types/ext_idle"]
 ext_enable = ["imap-types/ext_enable"]
 ext_compress = ["imap-types/ext_compress"]
-
+ext_quota = ["imap-types/ext_quota"]
 [dependencies]
 bounded-static = "0.4"
 libfuzzer-sys = "0.4"

--- a/imap-types/src/codec.rs
+++ b/imap-types/src/codec.rs
@@ -326,7 +326,7 @@ impl<'a> Encode for CommandBody<'a> {
                 quota_root.encode(writer)?;
                 writer.write_all(b" (")?;
                 join_serializable(resources.as_ref(), b" ", writer)?;
-                writer.write_all(b" )")
+                writer.write_all(b")")
             }
             #[cfg(feature = "ext_quota")]
             CommandBody::GetQuota { quota_root } => {
@@ -1028,7 +1028,7 @@ impl<'a> Encode for Data<'a> {
                 root_name.encode(writer)?;
                 writer.write_all(b" (")?;
                 join_serializable(resources.as_ref(), b" ", writer)?;
-                writer.write_all(b" )")?;
+                writer.write_all(b")")?;
             }
             #[cfg(feature = "ext_quota")]
             Data::QuotaRoot {
@@ -1038,8 +1038,9 @@ impl<'a> Encode for Data<'a> {
                 writer.write_all(b"* QUOTAROOT ")?;
                 mailbox_name.encode(writer)?;
                 if quota_roots.is_empty() {
-                    writer.write_all(b"\"\"")?;
+                    writer.write_all(b" \"\"")?;
                 } else {
+                    writer.write_all(b" ")?;
                     join_serializable(quota_roots, b" ", writer)?;
                 }
             }

--- a/imap-types/src/extensions/mod.rs
+++ b/imap-types/src/extensions/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "ext_quota")]
+pub mod rfc2087;
 #[cfg(feature = "ext_idle")]
 pub mod rfc2177;
 #[cfg(feature = "ext_compress")]

--- a/imap-types/src/extensions/rfc2087.rs
+++ b/imap-types/src/extensions/rfc2087.rs
@@ -1,0 +1,84 @@
+//! The IMAP QUOTA Extension
+//!
+//! This extension extends ...
+//!
+//! * the [Capability](crate::response::Capability::Quota) enum with a new variant:
+//!
+//!     - [Capability::Quota](crate::response::Capability#variant.Quota)
+//!
+//! * the [CommandBody](crate::command::CommandBody) enum with a new varients:
+//!
+//!     - [Command::SetQuota](crate::command::CommandBody::SetQuota)
+//!     - [Command::GetQuota](crate::command::CommandBody::GetQuota)
+//!     - [Command::GetQuotaRoot](crate::command::CommandBody::GetQuotaRoot)
+//!
+//! * the [Data](crate::response::Data) enum with new varients:
+//!
+//!     - [Data::Quota](crate::response::Data::Quota)
+//!     - [Data::QuotaRoot](crate::response::Data::QuotaRoot)
+//!
+
+pub use crate::core::AString;
+use crate::{codec::Encode, rfc3501::core::Atom};
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+#[cfg(feature = "bounded-static")]
+use bounded_static::ToStatic;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QuotaResouceCommand<'a> {
+    pub name: QuotaResourceName<'a>,
+    pub limit: u64,
+}
+
+impl<'a> Encode for QuotaResouceCommand<'a> {
+    fn encode(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
+        self.name.encode(writer)?;
+        write!(writer, " {}", self.limit)
+    }
+}
+
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QuotaResouceRespone<'a> {
+    pub name: QuotaResourceName<'a>,
+    pub usage: u64,
+    pub limit: u64,
+}
+
+impl<'a> Encode for QuotaResouceRespone<'a> {
+    fn encode(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
+        self.name.encode(writer)?;
+        write!(writer, " {} {}", self.usage, self.limit)
+    }
+}
+
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum QuotaResourceName<'a> {
+    /// Sum of messages' [RFC822](https://www.ietf.org/rfc/rfc822.txt).SIZE, in units of 1024 octets
+    /// [RFC822](https://www.ietf.org/rfc/rfc822.txt).SIZE is the number of octets in the entire message, including message headers.
+    Storage,
+    /// Number of messages
+    Message,
+    Atom(Atom<'a>),
+}
+
+impl<'a> Encode for QuotaResourceName<'a> {
+    fn encode(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
+        match self {
+            QuotaResourceName::Storage => writer.write_all(b"STORAGE"),
+            QuotaResourceName::Message => writer.write_all(b"MESSAGE"),
+            QuotaResourceName::Atom(atom) => atom.encode(writer),
+        }
+    }
+}

--- a/imap-types/src/extensions/rfc2087.rs
+++ b/imap-types/src/extensions/rfc2087.rs
@@ -31,12 +31,12 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct QuotaResouceCommand<'a> {
+pub struct SetQuotaResource<'a> {
     pub name: QuotaResourceName<'a>,
     pub limit: u64,
 }
 
-impl<'a> Encode for QuotaResouceCommand<'a> {
+impl<'a> Encode for SetQuotaResource<'a> {
     fn encode(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
         self.name.encode(writer)?;
         write!(writer, " {}", self.limit)
@@ -47,13 +47,13 @@ impl<'a> Encode for QuotaResouceCommand<'a> {
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct QuotaResouceRespone<'a> {
+pub struct QuotaResource<'a> {
     pub name: QuotaResourceName<'a>,
     pub usage: u64,
     pub limit: u64,
 }
 
-impl<'a> Encode for QuotaResouceRespone<'a> {
+impl<'a> Encode for QuotaResource<'a> {
     fn encode(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
         self.name.encode(writer)?;
         write!(writer, " {} {}", self.usage, self.limit)
@@ -81,4 +81,9 @@ impl<'a> Encode for QuotaResourceName<'a> {
             QuotaResourceName::Atom(atom) => atom.encode(writer),
         }
     }
+}
+
+
+mod tests {
+    
 }

--- a/imap-types/src/extensions/rfc2087.rs
+++ b/imap-types/src/extensions/rfc2087.rs
@@ -18,14 +18,15 @@
 //!     - [Data::QuotaRoot](crate::response::Data::QuotaRoot)
 //!
 
-pub use crate::core::AString;
-use crate::{codec::Encode, rfc3501::core::Atom};
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[cfg(feature = "bounded-static")]
 use bounded_static::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+pub use crate::core::AString;
+use crate::{codec::Encode, rfc3501::core::Atom};
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
@@ -87,9 +88,8 @@ impl<'a> Encode for QuotaResourceName<'a> {
 mod tests {
     use std::convert::TryInto;
 
-    use crate::{codec::Encode, response::Data, rfc3501::command::CommandBody};
-
     use super::{QuotaResource, QuotaResourceName, SetQuotaResource};
+    use crate::{codec::Encode, response::Data, rfc3501::command::CommandBody};
 
     fn compare_output(items: Vec<(Result<impl Encode, ()>, &str)>) {
         let mut writer: Vec<u8> = Vec::new();

--- a/imap-types/src/lib.rs
+++ b/imap-types/src/lib.rs
@@ -156,7 +156,12 @@
 
 #[cfg(feature = "arbitrary")]
 mod arbitrary;
-#[cfg(any(feature = "ext_idle", feature = "ext_enable", feature = "ext_compress"))]
+#[cfg(any(
+    feature = "ext_idle",
+    feature = "ext_enable",
+    feature = "ext_compress",
+    feature = "ext_quota"
+))]
 mod extensions;
 mod rfc3501;
 mod utils;
@@ -252,6 +257,10 @@ pub mod command {
     #[cfg(feature = "ext_idle")]
     pub mod idle {
         pub use crate::extensions::rfc2177::IdleDone;
+    }
+    #[cfg(feature = "ext_quota")]
+    pub mod quota {
+        pub use crate::extensions::rfc2087::*;
     }
 }
 

--- a/imap-types/src/rfc3501/command.rs
+++ b/imap-types/src/rfc3501/command.rs
@@ -17,7 +17,6 @@ use crate::extensions::rfc2087::SetQuotaResource;
 use crate::extensions::rfc4987::CompressionAlgorithm;
 #[cfg(feature = "ext_enable")]
 use crate::extensions::rfc5161::CapabilityEnable;
-
 use crate::{
     command::{
         fetch::MacroOrFetchAttributes,

--- a/imap-types/src/rfc3501/command.rs
+++ b/imap-types/src/rfc3501/command.rs
@@ -1498,7 +1498,7 @@ impl<'a> CommandBody<'a> {
         })
     }
     #[cfg(feature = "ext_quota")]
-    pub fn get_quota_roo<A>(mailbox_name: A) -> Result<Self, A::Error>
+    pub fn get_quota_root<A>(mailbox_name: A) -> Result<Self, A::Error>
     where
         A: TryInto<AString<'a>>,
     {
@@ -1874,6 +1874,10 @@ mod test {
             CommandBody::enable(vec![CapabilityEnable::Utf8(Utf8Kind::Accept)]).unwrap(),
             #[cfg(feature = "ext_compress")]
             CommandBody::compress(CompressionAlgorithm::Deflate),
+            #[cfg(feature = "ext_quota")]
+            CommandBody::get_quota("INBOX").unwrap(),
+            #[cfg(feature = "ext_quota")]
+            CommandBody::get_quota_root("MAILBOX").unwrap(),
         ];
 
         for (no, cmd_body) in cmds.into_iter().enumerate() {

--- a/imap-types/src/rfc3501/response.rs
+++ b/imap-types/src/rfc3501/response.rs
@@ -14,7 +14,7 @@ use bounded_static::ToStatic;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "ext_quota")]
-use crate::extensions::rfc2087::QuotaResouceRespone;
+use crate::extensions::rfc2087::QuotaResource;
 #[cfg(feature = "ext_compress")]
 use crate::extensions::rfc4987::CompressionAlgorithm;
 #[cfg(feature = "ext_enable")]
@@ -507,7 +507,7 @@ pub enum Data<'a> {
         /// Name of Mailbox
         root_name: AString<'a>,
         /// Zero or More Quota Root Names
-        resources: Vec<QuotaResouceRespone<'a>>,
+        resources: Vec<QuotaResource<'a>>,
     },
 
     /// [5.2. QUOTAROOT Response](https://www.rfc-editor.org/rfc/rfc2087#section-5.2)

--- a/imap-types/src/rfc3501/response.rs
+++ b/imap-types/src/rfc3501/response.rs
@@ -20,14 +20,13 @@ use crate::extensions::rfc4987::CompressionAlgorithm;
 #[cfg(feature = "ext_enable")]
 use crate::extensions::rfc5161::CapabilityEnable;
 use crate::{
-    core::{Atom, NonEmptyVec,AString},
+    core::{AString, Atom, NonEmptyVec},
     message::{AuthMechanism, Charset, Flag, FlagNameAttribute, Mailbox, Tag},
     response::{
         data::{FetchAttributeValue, QuotedChar, StatusAttributeValue},
         Text,
     },
 };
-
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]

--- a/imap-types/src/rfc3501/response.rs
+++ b/imap-types/src/rfc3501/response.rs
@@ -20,7 +20,7 @@ use crate::extensions::rfc4987::CompressionAlgorithm;
 #[cfg(feature = "ext_enable")]
 use crate::extensions::rfc5161::CapabilityEnable;
 use crate::{
-    core::{Atom, NonEmptyVec},
+    core::{Atom, NonEmptyVec,AString},
     message::{AuthMechanism, Charset, Flag, FlagNameAttribute, Mailbox, Tag},
     response::{
         data::{FetchAttributeValue, QuotedChar, StatusAttributeValue},
@@ -28,7 +28,6 @@ use crate::{
     },
 };
 
-use super::core::AString;
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
@@ -577,7 +576,29 @@ impl<'a> Data<'a> {
             attributes: attributes.try_into().map_err(|_| ())?, // TODO: better error
         })
     }
+    #[cfg(feature = "ext_quota")]
+    pub fn quota<A, B>(name: A, resources: B) -> Result<Self, ()>
+    where
+        A: TryInto<AString<'a>>,
+        B: TryInto<Vec<QuotaResource<'a>>>,
+    {
+        Ok(Self::Quota {
+            root_name: name.try_into().map_err(|_| ())?,
+            resources: resources.try_into().map_err(|_| ())?,
+        })
+    }
 
+    #[cfg(feature = "ext_quota")]
+    pub fn quota_root<A, B>(mailbox_name: A, quota_roots: B) -> Result<Self, ()>
+    where
+        A: TryInto<AString<'a>>,
+        B: TryInto<Vec<AString<'a>>>,
+    {
+        Ok(Self::QuotaRoot {
+            mailbox_name: mailbox_name.try_into().map_err(|_| ())?,
+            quota_roots: quota_roots.try_into().map_err(|_| ())?,
+        })
+    }
     // TODO
     // #[cfg(feature = "ext_enable")]
     // pub fn enable() -> Self {


### PR DESCRIPTION
Howdy.  

This PR adds support in the sub-crate imap-types for [RFC2087](https://www.rfc-editor.org/rfc/rfc2087). 

For now, I added the feature flag `ext_quota` to `imap-types`, and applied it to any new additions. I plan to implement the same in `imap-codec` however it'll be a bit before I can get to that. Submitting this PR as in the interim as it should be able to work independently.

- Tests are located in `imap-types/src/extensions/rfc2087.rs` to validate it generates the correct output.

- I included documentation from the RFC wherever applicable

Let me know if there's anything else I'd need to add/change. 