### PR TITLE
fix(misuse): Fix `Body` misuse.

### DIFF
--- a/imap-types/src/codec.rs
+++ b/imap-types/src/codec.rs
@@ -1209,7 +1209,7 @@ impl<'a> Encode for BodyStructure<'a> {
                 subtype,
                 extension_data,
             } => {
-                for body in bodies {
+                for body in &bodies.inner {
                     body.encode(writer)?;
                 }
                 writer.write_all(b" ")?;

--- a/imap-types/src/rfc3501/body.rs
+++ b/imap-types/src/rfc3501/body.rs
@@ -8,7 +8,7 @@ use bounded_static::ToStatic;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    core::{IString, NString},
+    core::{IString, NString, NonEmptyVec},
     response::data::Envelope,
 };
 
@@ -240,7 +240,7 @@ pub enum BodyStructure<'a> {
     /// )
     /// ```
     Multi {
-        bodies: Vec<BodyStructure<'a>>,
+        bodies: NonEmptyVec<BodyStructure<'a>>,
         subtype: IString<'a>,
         extension_data: Option<MultiPartExtensionData<'a>>,
     },

--- a/src/rfc3501/body.rs
+++ b/src/rfc3501/body.rs
@@ -1,8 +1,8 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, convert::TryFrom};
 
 use abnf_core::streaming::SP;
 use imap_types::{
-    core::{IString, NString},
+    core::{IString, NString, NonEmptyVec},
     response::data::{
         BasicFields, Body, BodyStructure, MultiPartExtensionData, SinglePartExtensionData,
         SpecificFields,
@@ -435,7 +435,8 @@ fn body_type_mpart_limited(
     Ok((
         remaining,
         BodyStructure::Multi {
-            bodies,
+            // Safety: `unwrap` can't panic due to the use of `many1`.
+            bodies: NonEmptyVec::try_from(bodies).unwrap(),
             subtype,
             extension_data,
         },


### PR DESCRIPTION
This fixes #121.