### PR TITLE
fix(misuse): Introduce `CodeOther`.

### DIFF
--- a/imap-types/src/arbitrary/mod.rs
+++ b/imap-types/src/arbitrary/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     message::{AuthMechanismOther, Mailbox, MyDateTime, MyNaiveDate, Tag},
     response::{
         data::{CapabilityOther, QuotedChar},
-        Text,
+        CodeOther, Text,
     },
 };
 
@@ -53,6 +53,7 @@ implement_tryfrom! { ListCharString<'a>, &str }
 implement_tryfrom! { QuotedChar, char }
 implement_tryfrom! { Mailbox<'a>, &str }
 implement_tryfrom! { CapabilityOther<'a>, Atom<'a> }
+implement_tryfrom! { CodeOther<'a>, Atom<'a> }
 #[cfg(feature = "ext_quota")]
 implement_tryfrom! { ResourceOther<'a>, Atom<'a> }
 implement_tryfrom! { AuthMechanismOther<'a>, Atom<'a> }

--- a/imap-types/src/lib.rs
+++ b/imap-types/src/lib.rs
@@ -256,7 +256,7 @@ pub mod response {
 
     pub use crate::rfc3501::{
         core::Text,
-        response::{Code, Continue, Data, Greeting, GreetingKind, Response, Status},
+        response::{Code, CodeOther, Continue, Data, Greeting, GreetingKind, Response, Status},
     };
 
     pub mod data {


### PR DESCRIPTION
This fixes #120. (Merge after #125.)