### PR TITLE
feat: Introduce `Context` in `Encode` trait.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fn main() {
     let (remainder, parsed) = Command::decode(input).unwrap();
     println!("# Parsed\n\n{:#?}\n\n", parsed);
 
-    let buffer = parsed.encode_detached().unwrap();
+    let buffer = parsed.encode_detached(&Context::default()).unwrap();
 
     // Note: IMAP4rev1 may produce messages that are not valid UTF-8.
     println!("# Serialized\n\n{:?}", std::str::from_utf8(&buffer));

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Status(Ok { tag: None, code: None, text: Text("IMAP4rev1 Service Ready") })
 // * OK IMAP4rev1 Service Ready
 
 // a001 login mrc secret
-Command { tag: Tag("a001"), body: Login { username: Atom(AtomExt("mrc")), password: [[REDACTED]] } }
+Command { tag: Tag("a001"), body: Login { username: Atom(AtomExt("mrc")), password: /* REDACTED */ } }
 // a001 LOGIN mrc secret
 
 // a001 OK LOGIN completed

--- a/fuzz/fuzz_targets/command.rs
+++ b/fuzz/fuzz_targets/command.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "debug")]
 use imap_codec::utils::escape_byte_string;
 use imap_codec::{
-    codec::{Decode, Encode},
+    codec::{Context, Decode, Encode},
     command::Command,
 };
 use libfuzzer_sys::fuzz_target;
@@ -20,7 +20,7 @@ fuzz_target!(|data: &[u8]| {
             println!("[!] Parsed1: {parsed1:?}");
         }
 
-        let output = parsed1.encode_detached().unwrap();
+        let output = parsed1.encode_detached(&Context::default()).unwrap();
         #[cfg(feature = "debug")]
         println!("[!] Serialized: {}", escape_byte_string(&output));
 

--- a/fuzz/fuzz_targets/command_to_bytes_and_back.rs
+++ b/fuzz/fuzz_targets/command_to_bytes_and_back.rs
@@ -5,7 +5,7 @@ use imap_codec::message::CapabilityEnable;
 #[cfg(feature = "debug")]
 use imap_codec::utils::escape_byte_string;
 use imap_codec::{
-    codec::{Decode, Encode},
+    codec::{Context, Decode, Encode},
     command::{search::SearchKey, Command, CommandBody},
     message::Flag,
 };
@@ -72,7 +72,7 @@ fuzz_target!(|test: Command| {
     #[cfg(feature = "debug")]
     println!("[!] Input: {test:?}");
 
-    let buffer = test.encode_detached().unwrap();
+    let buffer = test.encode_detached(&Context::default()).unwrap();
 
     #[cfg(feature = "debug")]
     println!("[!] Serialzed: {}", escape_byte_string(&buffer));

--- a/fuzz/fuzz_targets/greeting.rs
+++ b/fuzz/fuzz_targets/greeting.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "debug")]
 use imap_codec::utils::escape_byte_string;
 use imap_codec::{
-    codec::{Decode, Encode},
+    codec::{Context, Decode, Encode},
     response::Greeting,
 };
 use libfuzzer_sys::fuzz_target;
@@ -20,7 +20,7 @@ fuzz_target!(|data: &[u8]| {
             println!("[!] Parsed1: {parsed1:?}");
         }
 
-        let output = parsed1.encode_detached().unwrap();
+        let output = parsed1.encode_detached(&Context::default()).unwrap();
         #[cfg(feature = "debug")]
         println!("[!] Serialized: {}", escape_byte_string(&output));
 

--- a/fuzz/fuzz_targets/greeting_to_bytes_and_back.rs
+++ b/fuzz/fuzz_targets/greeting_to_bytes_and_back.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "debug")]
 use imap_codec::utils::escape_byte_string;
 use imap_codec::{
-    codec::{Decode, Encode},
+    codec::{Context, Decode, Encode},
     response::{Code, Greeting},
 };
 use libfuzzer_sys::fuzz_target;
@@ -33,7 +33,7 @@ fuzz_target!(|test: Greeting| {
     #[cfg(feature = "debug")]
     println!("[!] Input: {test:?}");
 
-    let buffer = test.encode_detached().unwrap();
+    let buffer = test.encode_detached(&Context::default()).unwrap();
 
     #[cfg(feature = "debug")]
     println!("[!] Serialized: {}", escape_byte_string(&buffer));

--- a/fuzz/fuzz_targets/response.rs
+++ b/fuzz/fuzz_targets/response.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "debug")]
 use imap_codec::utils::escape_byte_string;
 use imap_codec::{
-    codec::{Decode, Encode},
+    codec::{Context, Decode, Encode},
     response::Response,
 };
 use libfuzzer_sys::fuzz_target;
@@ -20,7 +20,7 @@ fuzz_target!(|data: &[u8]| {
             println!("[!] Parsed1: {parsed1:?}");
         }
 
-        let output = parsed1.encode_detached().unwrap();
+        let output = parsed1.encode_detached(&Context::default()).unwrap();
         #[cfg(feature = "debug")]
         println!("[!] Serialized: {}", escape_byte_string(&output));
 

--- a/fuzz/fuzz_targets/response_to_bytes_and_back.rs
+++ b/fuzz/fuzz_targets/response_to_bytes_and_back.rs
@@ -4,7 +4,7 @@ use base64::{engine::general_purpose::STANDARD as _base64, Engine};
 #[cfg(feature = "debug")]
 use imap_codec::utils::escape_byte_string;
 use imap_codec::{
-    codec::{Decode, Encode},
+    codec::{Context, Decode, Encode},
     response::{data::FetchAttributeValue, Code, Continue, Data, Response},
 };
 use libfuzzer_sys::fuzz_target;
@@ -84,7 +84,7 @@ fuzz_target!(|test: Response| {
     #[cfg(feature = "debug")]
     println!("[!] Input: {test:?}");
 
-    let buffer = test.encode_detached().unwrap();
+    let buffer = test.encode_detached(&Context::default()).unwrap();
 
     #[cfg(feature = "debug")]
     println!("[!] Serialized: {}", escape_byte_string(&buffer));

--- a/imap-types/benches/serialize_command.rs
+++ b/imap-types/benches/serialize_command.rs
@@ -2,7 +2,7 @@ use std::{convert::TryFrom, num::NonZeroU32};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use imap_types::{
-    codec::Encode,
+    codec::{Context, Encode},
     command::{
         fetch::{FetchAttribute, MacroOrFetchAttributes},
         Command, CommandBody,
@@ -11,7 +11,7 @@ use imap_types::{
 };
 
 fn serialize_command(cmd: &Command, out: &mut Vec<u8>) {
-    cmd.encode(out).unwrap();
+    cmd.encode(out, &Context::default()).unwrap();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/imap-types/benches/serialize_response.rs
+++ b/imap-types/benches/serialize_response.rs
@@ -2,12 +2,12 @@ use std::{convert::TryInto, num::NonZeroU32};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use imap_types::{
-    codec::Encode,
+    codec::{Context, Encode},
     response::{Code, Response, Status},
 };
 
 fn serialize_response(rsp: &Response, out: &mut Vec<u8>) {
-    rsp.encode(out).unwrap();
+    rsp.encode(out, &Context::default()).unwrap();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/imap-types/src/extensions/rfc2177.rs
+++ b/imap-types/src/extensions/rfc2177.rs
@@ -22,7 +22,7 @@ use bounded_static::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::codec::Encode;
+use crate::codec::{Context, Encode};
 
 /// Denotes the continuation data message "DONE\r\n" to end the IDLE command.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -32,7 +32,7 @@ use crate::codec::Encode;
 pub struct IdleDone;
 
 impl Encode for IdleDone {
-    fn encode(&self, writer: &mut impl Write) -> std::io::Result<()> {
+    fn encode(&self, writer: &mut impl Write, _: &Context) -> std::io::Result<()> {
         writer.write_all(b"DONE\r\n")
     }
 }

--- a/imap-types/src/extensions/rfc4987.rs
+++ b/imap-types/src/extensions/rfc4987.rs
@@ -19,7 +19,11 @@ use bounded_static::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{codec::Encode, core::Atom, rfc3501::core::impl_try_from_try_from};
+use crate::{
+    codec::{Context, Encode},
+    core::Atom,
+    rfc3501::core::impl_try_from_try_from,
+};
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
@@ -55,7 +59,7 @@ impl AsRef<str> for CompressionAlgorithm {
 }
 
 impl Encode for CompressionAlgorithm {
-    fn encode(&self, writer: &mut impl Write) -> std::io::Result<()> {
+    fn encode(&self, writer: &mut impl Write, _: &Context) -> std::io::Result<()> {
         match self {
             CompressionAlgorithm::Deflate => writer.write_all(b"DEFLATE"),
         }

--- a/imap-types/src/extensions/rfc5161.rs
+++ b/imap-types/src/extensions/rfc5161.rs
@@ -15,7 +15,10 @@ use bounded_static::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{codec::Encode, core::Atom};
+use crate::{
+    codec::{Context, Encode},
+    core::Atom,
+};
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
@@ -36,11 +39,11 @@ pub enum Utf8Kind {
 }
 
 impl<'a> Encode for CapabilityEnable<'a> {
-    fn encode(&self, writer: &mut impl Write) -> std::io::Result<()> {
+    fn encode(&self, writer: &mut impl Write, ctx: &Context) -> std::io::Result<()> {
         match self {
             Self::Utf8(Utf8Kind::Accept) => writer.write_all(b"UTF8=ACCEPT"),
             Self::Utf8(Utf8Kind::Only) => writer.write_all(b"UTF8=ONLY"),
-            Self::Other(atom) => atom.encode(writer),
+            Self::Other(atom) => atom.encode(writer, ctx),
         }
     }
 }

--- a/imap-types/src/lib.rs
+++ b/imap-types/src/lib.rs
@@ -74,7 +74,7 @@
 //! let cmd = Command::new("A123", CommandBody::login("alice", "password").unwrap()).unwrap();
 //!
 //! // Encode the `cmd` into `out`.
-//! let out = cmd.encode_detached().unwrap();
+//! let out = cmd.encode_detached(&Context::default()).unwrap();
 //!
 //! // Print the command.
 //! // (Note that IMAP traces are not guaranteed to be valid UTF-8.)

--- a/imap-types/src/rfc3501/command.rs
+++ b/imap-types/src/rfc3501/command.rs
@@ -1765,7 +1765,7 @@ mod tests {
     #[cfg(feature = "ext_quota")]
     use crate::extensions::rfc9208::{QuotaSet, Resource};
     use crate::{
-        codec::Encode,
+        codec::{Context, Encode},
         command::{
             fetch::{FetchAttribute, Macro},
             search::SearchKey,
@@ -1953,7 +1953,7 @@ mod tests {
             println!("Test: {}, {:?}", no, cmd_body);
 
             let cmd = cmd_body.tag(format!("A{}", no)).unwrap();
-            let serialized = cmd.encode_detached().unwrap();
+            let serialized = cmd.encode_detached(&Context::default()).unwrap();
             let printable = String::from_utf8_lossy(&serialized);
             print!("Serialized: {}", printable);
         }
@@ -1971,7 +1971,7 @@ mod tests {
         )
         .unwrap();
 
-        let buffer = command.encode_detached().unwrap();
+        let buffer = command.encode_detached(&Context::default()).unwrap();
 
         assert_eq!(buffer, b"A AUTHENTICATE PLAIN =\r\n")
     }

--- a/imap-types/src/rfc3501/core.rs
+++ b/imap-types/src/rfc3501/core.rs
@@ -902,7 +902,7 @@ mod tests {
     use std::{convert::TryInto, str::from_utf8};
 
     use super::*;
-    use crate::codec::Encode;
+    use crate::codec::{Context, Encode};
 
     #[test]
     fn test_atom() {
@@ -1151,7 +1151,7 @@ mod tests {
             let cs = Charset::try_from(*from).unwrap();
             println!("{:?}", cs);
 
-            let out = cs.encode_detached().unwrap();
+            let out = cs.encode_detached(&Context::default()).unwrap();
             assert_eq!(from_utf8(&out).unwrap(), *expected);
         }
 

--- a/imap-types/src/rfc3501/response.rs
+++ b/imap-types/src/rfc3501/response.rs
@@ -983,7 +983,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use super::*;
-    use crate::codec::Encode;
+    use crate::codec::{Context, Encode};
 
     #[test]
     fn test_greeting() {
@@ -994,7 +994,7 @@ mod tests {
 
         for (parsed, serialized) in tests.into_iter() {
             eprintln!("{:?}", parsed);
-            let out = parsed.encode_detached().unwrap();
+            let out = parsed.encode_detached(&Context::default()).unwrap();
             assert_eq!(out, serialized.to_vec());
             // FIXME(#30):
             //assert_eq!(parsed, Data::deserialize(serialized).unwrap().1);
@@ -1066,7 +1066,7 @@ mod tests {
 
         for (constructed, serialized) in tests {
             let constructed = constructed.unwrap();
-            let out = constructed.encode_detached().unwrap();
+            let out = constructed.encode_detached(&Context::default()).unwrap();
 
             assert_eq!(out, serialized.to_vec());
             // FIXME(#30)
@@ -1108,7 +1108,7 @@ mod tests {
 
         for (parsed, serialized) in tests.into_iter() {
             eprintln!("{:?}", parsed);
-            let out = parsed.encode_detached().unwrap();
+            let out = parsed.encode_detached(&Context::default()).unwrap();
             assert_eq!(out, serialized.to_vec());
             // FIXME(#30):
             //assert_eq!(parsed, Data::deserialize(serialized).unwrap().1);
@@ -1133,7 +1133,7 @@ mod tests {
 
         for (constructed, serialized) in tests.into_iter() {
             let constructed = constructed.unwrap();
-            let out = constructed.encode_detached().unwrap();
+            let out = constructed.encode_detached(&Context::default()).unwrap();
             assert_eq!(out, serialized.to_vec());
             // FIXME(#30):
             //assert_eq!(parsed, Continuation::deserialize(serialized).unwrap().1);

--- a/imap-types/src/rfc3501/sequence.rs
+++ b/imap-types/src/rfc3501/sequence.rs
@@ -263,7 +263,10 @@ mod tests {
     };
 
     use super::{SeqNo, Sequence, Strategy};
-    use crate::{codec::Encode, command::SequenceSet};
+    use crate::{
+        codec::{Context, Encode},
+        command::SequenceSet,
+    };
 
     #[test]
     fn creation_of_sequence_from_range() {
@@ -439,7 +442,7 @@ mod tests {
         ];
 
         for (test, expected) in tests {
-            let out = test.encode_detached().unwrap();
+            let out = test.encode_detached(&Context::default()).unwrap();
             assert_eq!(*expected, out);
         }
     }

--- a/imap-types/src/security.rs
+++ b/imap-types/src/security.rs
@@ -59,7 +59,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        codec::Encode,
+        codec::{Context, Encode},
         command::{AuthenticateData, CommandBody},
         message::AuthMechanism,
         security::Secret,
@@ -92,7 +92,7 @@ mod tests {
         for test in tests.into_iter() {
             println!(
                 "Serialized: {:?}",
-                String::from_utf8(test.encode_detached().unwrap()),
+                String::from_utf8(test.encode_detached(&Context::default()).unwrap()),
             );
 
             let got = format!("{:?}", test);
@@ -109,7 +109,7 @@ mod tests {
         let test = AuthenticateData(Secret::new(b"xyz123".to_vec()));
         println!(
             "Serialized: {:?}",
-            String::from_utf8(test.encode_detached().unwrap()),
+            String::from_utf8(test.encode_detached(&Context::default()).unwrap()),
         );
 
         let got = format!("{:?}", test);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,4 +1,4 @@
-pub use imap_types::codec::Encode;
+pub use imap_types::codec::{Context, Encode};
 #[cfg(feature = "ext_idle")]
 use imap_types::command::idle::IdleDone;
 use imap_types::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! println!("// Parsed:");
 //! println!("{:#?}", parsed);
 //!
-//! let serialized = parsed.encode_detached().unwrap();
+//! let serialized = parsed.encode_detached(&Context::default()).unwrap();
 //!
 //! let serialized = String::from_utf8(serialized).unwrap(); // Not every IMAP message is valid UTF-8.
 //! println!("// Serialized:"); // We just ignore that, so that we can print the message.

--- a/src/tokio_compat/server.rs
+++ b/src/tokio_compat/server.rs
@@ -1,7 +1,7 @@
 use std::io::Error;
 
 use bytes::{Buf, BufMut, BytesMut};
-use imap_types::{bounded_static::IntoBoundedStatic, response::Greeting};
+use imap_types::{bounded_static::IntoBoundedStatic, codec::Context, response::Greeting};
 use tokio_util::codec::{Decoder, Encoder};
 
 use super::{find_crlf_inclusive, parse_literal, LineError, LiteralError, LiteralFramingState};
@@ -15,6 +15,7 @@ use crate::{
 pub struct ImapServerCodec {
     state: LiteralFramingState,
     max_literal_size: usize,
+    context: Context,
 }
 
 impl ImapServerCodec {
@@ -22,6 +23,7 @@ impl ImapServerCodec {
         Self {
             state: LiteralFramingState::ReadLine { to_consume_acc: 0 },
             max_literal_size,
+            context: Context::default(),
         }
     }
 }
@@ -169,7 +171,7 @@ impl<'a> Encoder<&Greeting<'a>> for ImapServerCodec {
     fn encode(&mut self, item: &Greeting, dst: &mut BytesMut) -> Result<(), std::io::Error> {
         //dst.reserve(item.len());
         let mut writer = dst.writer();
-        item.encode(&mut writer).unwrap();
+        item.encode(&mut writer, &self.context).unwrap();
         Ok(())
     }
 }
@@ -180,7 +182,7 @@ impl<'a> Encoder<&Response<'a>> for ImapServerCodec {
     fn encode(&mut self, item: &Response, dst: &mut BytesMut) -> Result<(), std::io::Error> {
         //dst.reserve(item.len());
         let mut writer = dst.writer();
-        item.encode(&mut writer).unwrap();
+        item.encode(&mut writer, &self.context).unwrap();
         Ok(())
     }
 }

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -1,5 +1,5 @@
 use imap_codec::{
-    codec::{Decode, Encode},
+    codec::{Context, Decode, Encode},
     command::Command,
 };
 
@@ -10,7 +10,7 @@ fn test_from_readme() {
     let (_remainder, parsed) = Command::decode(input).unwrap();
     println!("# Parsed\n\n{:#?}\n\n", parsed);
 
-    let buffer = parsed.encode_detached().unwrap();
+    let buffer = parsed.encode_detached(&Context::default()).unwrap();
 
     // Note: IMAP4rev1 may produce messages that are not valid UTF-8.
     println!("# Serialized\n\n{:?}", std::str::from_utf8(&buffer));

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use imap_codec::{
-    codec::{Decode, Encode},
+    codec::{Context, Decode, Encode},
     command::{
         fetch::{FetchAttribute, Macro},
         Command, CommandBody,
@@ -75,7 +75,7 @@ fn test_lines_of_trace(trace: &[u8]) {
                 let (rem, parsed) = Command::decode(&line).unwrap();
                 assert!(rem.is_empty());
                 println!("Parsed      {:?}", parsed);
-                let serialized = parsed.encode_detached().unwrap();
+                let serialized = parsed.encode_detached(&Context::default()).unwrap();
                 println!(
                     "Serialized: {}",
                     String::from_utf8_lossy(&serialized).trim()
@@ -90,7 +90,7 @@ fn test_lines_of_trace(trace: &[u8]) {
                 let (rem, parsed) = Response::decode(&line).unwrap();
                 println!("Parsed:     {:?}", parsed);
                 assert!(rem.is_empty());
-                let serialized = parsed.encode_detached().unwrap();
+                let serialized = parsed.encode_detached(&Context::default()).unwrap();
                 println!(
                     "Serialized: {}",
                     String::from_utf8_lossy(&serialized).trim()
@@ -115,7 +115,7 @@ fn test_trace_known_positive(tests: Vec<(&[u8], Message)>) {
                 println!("{:?}", got);
                 println!(
                     "// {}",
-                    String::from_utf8(got.encode_detached().unwrap())
+                    String::from_utf8(got.encode_detached(&Context::default()).unwrap())
                         .unwrap()
                         .trim()
                 );
@@ -127,7 +127,7 @@ fn test_trace_known_positive(tests: Vec<(&[u8], Message)>) {
                 println!("{:?}", got);
                 println!(
                     "// {}",
-                    String::from_utf8(got.encode_detached().unwrap())
+                    String::from_utf8(got.encode_detached(&Context::default()).unwrap())
                         .unwrap()
                         .trim()
                 );
@@ -138,7 +138,7 @@ fn test_trace_known_positive(tests: Vec<(&[u8], Message)>) {
                 println!("{:?}", got);
                 println!(
                     "// {}",
-                    String::from_utf8(got.encode_detached().unwrap())
+                    String::from_utf8(got.encode_detached(&Context::default()).unwrap())
                         .unwrap()
                         .trim()
                 );
@@ -149,7 +149,7 @@ fn test_trace_known_positive(tests: Vec<(&[u8], Message)>) {
                 println!("{:?}", got);
                 println!(
                     "// {}",
-                    String::from_utf8(got.encode_detached().unwrap())
+                    String::from_utf8(got.encode_detached(&Context::default()).unwrap())
                         .unwrap()
                         .trim()
                 );
@@ -1050,7 +1050,7 @@ fn test_response_status_preauth() {
     let (rem, parsed) = Greeting::decode(line).unwrap();
     println!("Parsed:     {:?}", parsed);
     assert!(rem.is_empty());
-    let serialized = parsed.encode_detached().unwrap();
+    let serialized = parsed.encode_detached(&Context::default()).unwrap();
     println!(
         "Serialized: {}",
         String::from_utf8_lossy(&serialized).trim()


### PR DESCRIPTION
This closes #26. TODO: Implement `LITERAL+` (https://datatracker.ietf.org/doc/html/rfc7888#section-5).