### PR TITLE
refactor: Rename `seq_or_uid` to `seq` when used for sequence numbers only.

### DIFF
--- a/imap-types/src/lib.rs
+++ b/imap-types/src/lib.rs
@@ -69,7 +69,7 @@
 //!
 //! let fetch = {
 //!     let data = Data::Fetch {
-//!         seq_or_uid: NonZeroU32::new(42).unwrap(),
+//!         seq: NonZeroU32::new(42).unwrap(),
 //!         attributes: NonEmptyVec::try_from(vec![
 //!             FetchAttributeValue::Rfc822Size(1337),
 //!             FetchAttributeValue::Body(BodyStructure::Single {

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -509,7 +509,7 @@ pub enum Data<'a> {
     /// flag updates).
     Fetch {
         /// Message SEQ or UID
-        seq_or_uid: NonZeroU32,
+        seq: NonZeroU32,
         /// Message data
         attributes: NonEmptyVec<FetchAttributeValue<'a>>,
     },
@@ -569,17 +569,17 @@ impl<'a> Data<'a> {
     //     unimplemented!()
     // }
 
-    pub fn expunge(seq_or_uid: u32) -> Result<Self, TryFromIntError> {
-        Ok(Self::Expunge(NonZeroU32::try_from(seq_or_uid)?))
+    pub fn expunge(seq: u32) -> Result<Self, TryFromIntError> {
+        Ok(Self::Expunge(NonZeroU32::try_from(seq)?))
     }
 
-    pub fn fetch<I, A>(seq_or_uid: I, attributes: A) -> Result<Self, FetchError<I::Error, A::Error>>
+    pub fn fetch<I, A>(seq: I, attributes: A) -> Result<Self, FetchError<I::Error, A::Error>>
     where
         I: TryInto<NonZeroU32>,
         A: TryInto<NonEmptyVec<FetchAttributeValue<'a>>>,
     {
         Ok(Self::Fetch {
-            seq_or_uid: seq_or_uid.try_into().map_err(FetchError::SeqOrUid)?,
+            seq: seq.try_into().map_err(FetchError::SeqOrUid)?,
             attributes: attributes.try_into().map_err(FetchError::Attributes)?,
         })
     }

--- a/src/body.rs
+++ b/src/body.rs
@@ -639,7 +639,7 @@ mod tests {
             b"* 3372220415 FETCH (BODYSTRUCTURE ((((((({0}\r\n {0}\r\n NIL NIL NIL {0}\r\n 0 \"FOO\" NIL NIL \"LOCATION\" 1337) \"mixed\") \"mixed\") \"mixed\") \"mixed\") \"mixed\") \"mixed\"))\r\n".as_ref(),
             b"".as_ref(),
             Response::Data(Data::Fetch {
-                seq_or_uid: NonZeroU32::try_from(3372220415).unwrap(),
+                seq: NonZeroU32::try_from(3372220415).unwrap(),
                 attributes: NonEmptyVec::from(FetchAttributeValue::BodyStructure(
                     BodyStructure::Multi {
                         bodies: NonEmptyVec::from(BodyStructure::Multi {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -130,7 +130,7 @@ mod tests {
                 b"* 1 FETCH (RFC822 {5}\r\nhello)\r\n",
                 b"",
                 Response::Data(Data::Fetch {
-                    seq_or_uid: NonZeroU32::new(1).unwrap(),
+                    seq: NonZeroU32::new(1).unwrap(),
                     attributes: NonEmptyVec::from(FetchAttributeValue::Rfc822(NString(Some(
                         IString::Literal(Literal::try_from(b"hello".as_ref()).unwrap()),
                     )))),

--- a/src/codec/decode.rs
+++ b/src/codec/decode.rs
@@ -320,7 +320,7 @@ mod tests {
                 Ok((
                     b"".as_ref(),
                     Response::Data(Data::Fetch {
-                        seq_or_uid: NonZeroU32::new(1).unwrap(),
+                        seq: NonZeroU32::new(1).unwrap(),
                         attributes: NonEmptyVec::from(FetchAttributeValue::Rfc822(NString(Some(
                             IString::Literal(Literal::try_from(b"hello".as_ref()).unwrap()),
                         )))),

--- a/src/codec/encode.rs
+++ b/src/codec/encode.rs
@@ -1209,11 +1209,8 @@ impl<'a> Encoder for Data<'a> {
             Data::Exists(count) => write!(ctx, "* {count} EXISTS")?,
             Data::Recent(count) => write!(ctx, "* {count} RECENT")?,
             Data::Expunge(msg) => write!(ctx, "* {msg} EXPUNGE")?,
-            Data::Fetch {
-                seq_or_uid,
-                attributes,
-            } => {
-                write!(ctx, "* {seq_or_uid} FETCH (")?;
+            Data::Fetch { seq, attributes } => {
+                write!(ctx, "* {seq} FETCH (")?;
                 join_serializable(attributes.as_ref(), b" ", ctx)?;
                 ctx.write_all(b")")?;
             }
@@ -1864,7 +1861,7 @@ mod tests {
         kat_encoder(&[
             (
                 Response::Data(Data::Fetch {
-                    seq_or_uid: NonZeroU32::new(12345).unwrap(),
+                    seq: NonZeroU32::new(12345).unwrap(),
                     attributes: NonEmptyVec::from(FetchAttributeValue::BodyExt {
                         section: None,
                         origin: None,
@@ -1893,7 +1890,7 @@ mod tests {
             #[cfg(feature = "ext_literal")]
             (
                 Response::Data(Data::Fetch {
-                    seq_or_uid: NonZeroU32::new(12345).unwrap(),
+                    seq: NonZeroU32::new(12345).unwrap(),
                     attributes: NonEmptyVec::from(FetchAttributeValue::BodyExt {
                         section: None,
                         origin: None,

--- a/src/response.rs
+++ b/src/response.rs
@@ -352,16 +352,13 @@ pub fn response_fatal(input: &[u8]) -> IResult<&[u8], Status> {
 
 /// `message-data = nz-number SP ("EXPUNGE" / ("FETCH" SP msg-att))`
 pub fn message_data(input: &[u8]) -> IResult<&[u8], Data> {
-    let (remaining, seq_or_uid) = terminated(nz_number, SP)(input)?;
+    let (remaining, seq) = terminated(nz_number, SP)(input)?;
 
     alt((
-        map(tag_no_case(b"EXPUNGE"), move |_| Data::Expunge(seq_or_uid)),
+        map(tag_no_case(b"EXPUNGE"), move |_| Data::Expunge(seq)),
         map(
             tuple((tag_no_case(b"FETCH"), SP, msg_att)),
-            move |(_, _, attributes)| Data::Fetch {
-                seq_or_uid,
-                attributes,
-            },
+            move |(_, _, attributes)| Data::Fetch { seq, attributes },
         ),
     ))(remaining)
 }


### PR DESCRIPTION
This closes #242.