### PR TITLE
Add annotations to feature-gated items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,10 @@ harness = false
 name = "parse_response"
 harness = false
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [workspace]
 members = [
     "fuzz",

--- a/imap-types/Cargo.toml
+++ b/imap-types/Cargo.toml
@@ -44,3 +44,7 @@ thiserror = "1.0.29"
 [dev-dependencies]
 criterion = "0.4"
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/imap-types/src/command.rs
+++ b/imap-types/src/command.rs
@@ -156,6 +156,7 @@ pub enum CommandBody<'a> {
     /// STARTTLS.  The server MAY advertise different capabilities after
     /// STARTTLS.
     #[cfg(feature = "starttls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "starttls")))]
     StartTLS,
 
     /// ### 6.2.2.  AUTHENTICATE Command
@@ -251,6 +252,7 @@ pub enum CommandBody<'a> {
         mechanism: AuthMechanism<'a>,
         /// Already base64-decoded
         #[cfg(feature = "ext_sasl_ir")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "ext_sasl_ir")))]
         initial_response: Option<Secret<Cow<'a, [u8]>>>,
     },
 
@@ -374,6 +376,7 @@ pub enum CommandBody<'a> {
     Select { mailbox: Mailbox<'a> },
 
     #[cfg(feature = "ext_unselect")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_unselect")))]
     Unselect,
 
     /// 6.3.2.  EXAMINE Command
@@ -1175,14 +1178,17 @@ pub enum CommandBody<'a> {
     // by issuing the associated experimental command.
     //X,
     #[cfg(feature = "ext_idle")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_idle")))]
     Idle,
 
     #[cfg(feature = "ext_enable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_enable")))]
     Enable {
         capabilities: NonEmptyVec<CapabilityEnable<'a>>,
     },
 
     #[cfg(feature = "ext_compress")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_compress")))]
     Compress { algorithm: CompressionAlgorithm },
 
     /// Takes the name of a quota root and returns the quota root's resource usage and limits in an untagged QUOTA response.
@@ -1208,6 +1214,7 @@ pub enum CommandBody<'a> {
     /// S: G0001 OK Getquota complete
     /// ```
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     GetQuota {
         /// Name of quota root.
         root: AString<'a>,
@@ -1242,6 +1249,7 @@ pub enum CommandBody<'a> {
     /// S: G0002 OK Getquotaroot complete
     /// ```
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     GetQuotaRoot {
         /// Name of mailbox.
         mailbox: Mailbox<'a>,
@@ -1286,6 +1294,7 @@ pub enum CommandBody<'a> {
     /// S: S0002 NO Cannot change system limit
     /// ```
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     SetQuota {
         /// Name of quota root.
         root: AString<'a>,
@@ -1294,6 +1303,7 @@ pub enum CommandBody<'a> {
     },
 
     #[cfg(feature = "ext_move")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_move")))]
     Move {
         sequence_set: SequenceSet,
         mailbox: Mailbox<'a>,
@@ -1315,11 +1325,13 @@ impl<'a> CommandBody<'a> {
     // ----- Constructors -----
 
     #[cfg(not(feature = "ext_sasl_ir"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_sasl_ir")))]
     pub fn authenticate(mechanism: AuthMechanism<'a>) -> Self {
         CommandBody::Authenticate { mechanism }
     }
 
     #[cfg(feature = "ext_sasl_ir")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_sasl_ir")))]
     pub fn authenticate(mechanism: AuthMechanism<'a>, initial_response: Option<&'a [u8]>) -> Self {
         CommandBody::Authenticate {
             mechanism,

--- a/imap-types/src/core.rs
+++ b/imap-types/src/core.rs
@@ -85,6 +85,7 @@ impl<'a> Atom<'a> {
     }
 
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<C>(inner: C) -> Self
     where
         C: Into<Cow<'a, str>>,
@@ -199,6 +200,7 @@ impl<'a> AtomExt<'a> {
     }
 
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<C>(inner: C) -> Self
     where
         C: Into<Cow<'a, str>>,
@@ -388,7 +390,6 @@ impl<'a> AsRef<[u8]> for IString<'a> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Literal<'a> {
     pub(crate) data: Cow<'a, [u8]>,
-    #[cfg(feature = "ext_literal")]
     /// Specifies whether this is a synchronizing or non-synchronizing literal.
     ///
     /// `true` (default) denotes a synchronizing literal, e.g., `{3}\r\nfoo`.
@@ -396,6 +397,8 @@ pub struct Literal<'a> {
     ///
     /// Note: In the special case that a server advertised a `LITERAL-` capability, AND the literal
     /// has more than 4096 bytes a non-synchronizing literal must still be treated as synchronizing.
+    #[cfg(feature = "ext_literal")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_literal")))]
     pub sync: bool,
 }
 
@@ -418,12 +421,14 @@ impl<'a> Literal<'a> {
     }
 
     #[cfg(feature = "ext_literal")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_literal")))]
     pub fn into_sync(mut self) -> Self {
         self.sync = true;
         self
     }
 
     #[cfg(feature = "ext_literal")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_literal")))]
     pub fn into_non_sync(mut self) -> Self {
         self.sync = false;
         self
@@ -441,6 +446,7 @@ impl<'a> Literal<'a> {
     /// Call this function only when you are sure that the byte sequence
     /// is a valid literal, i.e., that it does not contain 0x00.
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<D>(data: D, #[cfg(feature = "ext_literal")] sync: bool) -> Self
     where
         D: Into<Cow<'a, [u8]>>,
@@ -566,6 +572,7 @@ impl<'a> Quoted<'a> {
     /// Call this function only when you are sure that the str
     /// is a valid quoted.
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<C>(inner: C) -> Self
     where
         C: Into<Cow<'a, str>>,
@@ -836,6 +843,7 @@ impl<'a> Tag<'a> {
     }
 
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<C>(inner: C) -> Self
     where
         C: Into<Cow<'a, str>>,
@@ -937,6 +945,7 @@ impl<'a> Text<'a> {
     }
 
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<C>(inner: C) -> Self
     where
         C: Into<Cow<'a, str>>,
@@ -1023,6 +1032,7 @@ impl QuotedChar {
     }
 
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked(inner: char) -> Self {
         #[cfg(debug_assertions)]
         Self::verify(inner).unwrap();
@@ -1143,6 +1153,7 @@ impl<T> NonEmptyVec<T> {
     }
 
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked(inner: Vec<T>) -> Self {
         #[cfg(debug_assertions)]
         Self::verify(&inner).unwrap();

--- a/imap-types/src/datetime.rs
+++ b/imap-types/src/datetime.rs
@@ -13,6 +13,7 @@ pub struct DateTime(chrono::DateTime<FixedOffset>);
 
 impl DateTime {
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked(value: chrono::DateTime<FixedOffset>) -> Self {
         Self(value)
     }
@@ -89,6 +90,7 @@ pub struct NaiveDate(chrono::NaiveDate);
 
 impl NaiveDate {
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked(value: chrono::NaiveDate) -> Self {
         Self(value)
     }

--- a/imap-types/src/extensions.rs
+++ b/imap-types/src/extensions.rs
@@ -1,14 +1,21 @@
 #[cfg(feature = "ext_compress")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_compress")))]
 pub mod compress;
 #[cfg(feature = "ext_enable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_enable")))]
 pub mod enable;
 #[cfg(feature = "ext_idle")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_idle")))]
 pub mod idle;
 #[cfg(feature = "ext_literal")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_literal")))]
 pub mod literal;
 #[cfg(feature = "ext_move")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_move")))]
 pub mod r#move;
 #[cfg(feature = "ext_quota")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
 pub mod quota;
 #[cfg(feature = "ext_unselect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_unselect")))]
 pub mod unselect;

--- a/imap-types/src/extensions/enable.rs
+++ b/imap-types/src/extensions/enable.rs
@@ -45,6 +45,7 @@ impl<'a> Data<'a> {
 pub enum CapabilityEnable<'a> {
     Utf8(Utf8Kind),
     #[cfg(feature = "ext_condstore_qresync")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_condstore_qresync")))]
     CondStore,
     Other(CapabilityEnableOther<'a>),
 }

--- a/imap-types/src/extensions/quota.rs
+++ b/imap-types/src/extensions/quota.rs
@@ -212,6 +212,7 @@ impl<'a> ResourceOther<'a> {
     }
 
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<C>(value: C) -> Self
     where
         C: Into<Cow<'a, str>>,

--- a/imap-types/src/lib.rs
+++ b/imap-types/src/lib.rs
@@ -100,6 +100,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_debug_implementations)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "arbitrary")]
 mod arbitrary;
@@ -118,6 +119,7 @@ pub mod envelope;
     feature = "ext_quota",
     feature = "ext_unselect",
 ))]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_*")))]
 pub mod extensions;
 pub mod fetch;
 pub mod flag;

--- a/imap-types/src/mailbox.rs
+++ b/imap-types/src/mailbox.rs
@@ -37,6 +37,7 @@ impl<'a> ListCharString<'a> {
     }
 
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<C>(inner: C) -> Self
     where
         C: Into<Cow<'a, str>>,

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -515,11 +515,13 @@ pub enum Data<'a> {
     },
 
     #[cfg(feature = "ext_enable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_enable")))]
     Enabled {
         capabilities: Vec<CapabilityEnable<'a>>,
     },
 
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     Quota {
         /// Quota root.
         root: AString<'a>,
@@ -528,6 +530,7 @@ pub enum Data<'a> {
     },
 
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     QuotaRoot {
         /// Mailbox name.
         mailbox: Mailbox<'a>,
@@ -779,18 +782,25 @@ pub enum Code<'a> {
     /// IMAP4 Login Referrals (RFC 2221)
     // TODO(misuse): the imap url is more complicated than that...
     #[cfg(any(feature = "ext_mailbox_referrals", feature = "ext_login_referrals"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "ext_mailbox_referrals", feature = "ext_login_referrals")))
+    )]
     Referral(Cow<'a, str>),
 
     #[cfg(feature = "ext_compress")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_compress")))]
     CompressionActive,
 
     /// SHOULD be returned in the tagged NO response to an APPEND/COPY/MOVE when the addition of the
     /// message(s) puts the target mailbox over any one of its quota limits.
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     OverQuota,
 
     /// Server got a non-synchronizing literal larger than 4096 bytes.
     #[cfg(feature = "ext_literal")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_literal")))]
     TooBig,
 
     /// Additional response codes defined by particular client or server
@@ -845,6 +855,7 @@ pub struct CodeOther<'a>(Cow<'a, [u8]>);
 
 impl<'a> CodeOther<'a> {
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<D: 'a>(data: D) -> Self
     where
         D: Into<Cow<'a, [u8]>>,
@@ -865,41 +876,54 @@ pub enum Capability<'a> {
     Imap4Rev1,
     Auth(AuthMechanism<'a>),
     #[cfg(feature = "starttls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "starttls")))]
     LoginDisabled,
     #[cfg(feature = "starttls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "starttls")))]
     StartTls,
     #[cfg(feature = "ext_idle")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_idle")))]
     /// See RFC 2177.
     Idle,
     /// See RFC 2193.
     #[cfg(feature = "ext_mailbox_referrals")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_mailbox_referrals")))]
     MailboxReferrals,
     /// See RFC 2221.
     #[cfg(feature = "ext_login_referrals")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_login_referrals")))]
     LoginReferrals,
     #[cfg(feature = "ext_sasl_ir")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_sasl_ir")))]
     SaslIr,
     /// See RFC 5161.
     #[cfg(feature = "ext_enable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_enable")))]
     Enable,
     #[cfg(feature = "ext_compress")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_compress")))]
     Compress {
         algorithm: CompressionAlgorithm,
     },
     /// See RFC 2087 and RFC 9208
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     Quota,
     /// See RFC 9208.
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     QuotaRes(Resource<'a>),
     /// See RFC 9208.
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     QuotaSet,
     /// See RFC 7888.
     #[cfg(feature = "ext_literal")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_literal")))]
     Literal(LiteralCapability),
     /// See RFC 6851.
     #[cfg(feature = "ext_move")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_move")))]
     Move,
     /// Other/Unknown
     Other(CapabilityOther<'a>),
@@ -1008,6 +1032,7 @@ pub struct CapabilityOther<'a>(pub(crate) Atom<'a>);
 
 impl<'a> CapabilityOther<'a> {
     #[cfg(feature = "unchecked")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unchecked")))]
     pub fn unchecked<C>(inner: C) -> Self
     where
         C: Into<Cow<'a, str>>,

--- a/imap-types/src/state.rs
+++ b/imap-types/src/state.rs
@@ -91,9 +91,11 @@ pub enum State<'a> {
     Logout,
 
     #[cfg(feature = "ext_idle")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_idle")))]
     IdleAuthenticated(Tag<'a>),
 
     #[cfg(feature = "ext_idle")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_idle")))]
     IdleSelected(Tag<'a>, Mailbox<'a>),
 }
 

--- a/imap-types/src/status.rs
+++ b/imap-types/src/status.rs
@@ -30,13 +30,16 @@ pub enum StatusAttribute {
 
     /// The number of messages with the \Deleted flag set.
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     Deleted,
 
     /// The amount of storage space that can be reclaimed by performing EXPUNGE on the mailbox.
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     DeletedStorage,
 
     #[cfg(feature = "ext_condstore_qresync")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_condstore_qresync")))]
     HighestModSeq,
 }
 
@@ -65,9 +68,11 @@ pub enum StatusAttributeValue {
 
     /// The number of messages with the \Deleted flag set.
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     Deleted(u32),
 
     /// The amount of storage space that can be reclaimed by performing EXPUNGE on the mailbox.
     #[cfg(feature = "ext_quota")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
     DeletedStorage(u64),
 }

--- a/src/codec/decode.rs
+++ b/src/codec/decode.rs
@@ -67,6 +67,7 @@ impl<'a> Decode<'a> for AuthenticateData {
 }
 
 #[cfg(feature = "ext_idle")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_idle")))]
 impl<'a> Decode<'a> for IdleDone {
     fn decode(input: &'a [u8]) -> Result<(&'a [u8], Self), DecodeError> {
         match idle_done(input) {

--- a/src/codec/encode.rs
+++ b/src/codec/encode.rs
@@ -106,6 +106,7 @@ pub enum Fragment {
     Literal {
         data: Vec<u8>,
         #[cfg(feature = "ext_literal")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "ext_literal")))]
         sync: bool,
     },
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -356,6 +356,7 @@ pub fn authenticate(input: &[u8]) -> IResult<&[u8], AuthMechanism> {
 ///                CRLF is parsed by upper command parser.
 /// ```
 #[cfg(feature = "ext_sasl_ir")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_sasl_ir")))]
 #[allow(clippy::type_complexity)]
 pub fn authenticate_sasl_ir(
     input: &[u8],

--- a/src/core.rs
+++ b/src/core.rs
@@ -41,6 +41,7 @@ pub fn number(input: &[u8]) -> IResult<&[u8], u32> {
 ///
 /// Defined in RFC 9051
 #[cfg(feature = "ext_quota")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
 pub fn number64(input: &[u8]) -> IResult<&[u8], u64> {
     map_res(
         // # Safety

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,14 +1,21 @@
 #[cfg(feature = "ext_compress")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_compress")))]
 pub mod compress;
 #[cfg(feature = "ext_enable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_enable")))]
 pub mod enable;
 #[cfg(feature = "ext_idle")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_idle")))]
 pub mod idle;
 #[cfg(feature = "ext_literal")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_literal")))]
 pub mod literal;
 #[cfg(feature = "ext_move")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_move")))]
 pub mod r#move;
 #[cfg(feature = "ext_quota")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_quota")))]
 pub mod quota;
 #[cfg(feature = "ext_unselect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_unselect")))]
 pub mod unselect;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_debug_implementations)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod auth;
 pub mod body;
@@ -177,6 +178,7 @@ pub mod envelope;
     feature = "ext_quota",
     feature = "ext_unselect",
 ))]
+#[cfg_attr(docsrs, doc(cfg(feature = "ext_*")))]
 pub mod extensions;
 pub mod fetch;
 pub mod flag;
@@ -189,5 +191,6 @@ pub mod status;
 #[cfg(test)]
 mod testing;
 #[cfg(any(feature = "tokio"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod tokio;
 pub use imap_types::{secret, state, utils};


### PR DESCRIPTION
This PR:

- Customizes the docs.rs build. When building the documentation docs.rs will now use `--all-features` and set the configuration flag `docsrs`. See [here](https://docs.rs/about/metadata) for reference.
-  Enables the nightly feature [doc_cfg](https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html) if the configuration flag "docsrs" is set. It allows us to add annotations to feature-gates items. For this it's necessary to build the documentation with a nightly compiler.
- Adds annotations to all feature-gates items for the features `tokio`, `unchecked`, `starttls` and `ext_*` via `doc(cfg(feature = "..."))`.

There are some caveats:

- Even though it's possible to add an annotation to a feature-gated trait implementation (`impl Foo for Bar`), that's not possible for derived trait implementations (`#[derive(Foo)] struct Bar`). This effects `serde`, `arbitrary` and `bounded-static`. I decided to not annotate any trait implementations for these libraries, even if the traits are implemented manually for some types. I suggest to document these feature-gates on the top-level page.
- It's not possible to add an annotation to a feature-gated function parameter (e.g. the parameter `sync` of the function `Literal::unchecked`). I suggest to document the feature-gate in the function documentation.

The result can be tested with:
```
RUSTFLAGS="--cfg docsrs" RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --all-features
```

The result looks like this:
![image](https://github.com/duesee/imap-codec/assets/44508205/8ff6589d-59d8-4b63-937f-8f63512d4d77)

Resolves #232