### PR TITLE
docs: Add documentation to `core` (and some other items).

### DIFF
--- a/imap-types/src/extensions.rs
+++ b/imap-types/src/extensions.rs
@@ -1,3 +1,5 @@
+//! IMAP extensions.
+
 #[cfg(feature = "ext_compress")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ext_compress")))]
 pub mod compress;

--- a/imap-types/src/secret.rs
+++ b/imap-types/src/secret.rs
@@ -1,3 +1,8 @@
+//! Handling of secret values.
+//!
+//! This module provides a `Secret<T>` ensuring that secret values are neither logged nor compared
+//! in non-constant time.
+
 use std::{
     borrow::Cow,
     fmt::{Debug, Formatter},

--- a/imap-types/src/state.rs
+++ b/imap-types/src/state.rs
@@ -1,4 +1,4 @@
-//! # State and Flow Diagram
+//! IMAP protocol state.
 //!
 //! "Once the connection between client and server is established, an IMAP4rev1 connection is in one of four states.
 //! The initial state is identified in the server greeting.

--- a/imap-types/src/utils.rs
+++ b/imap-types/src/utils.rs
@@ -32,7 +32,6 @@ pub mod indicators {
     /// Any 7-bit US-ASCII character, excluding NUL
     ///
     /// CHAR = %x01-7F
-    #[allow(non_snake_case)]
     pub fn is_char(byte: u8) -> bool {
         matches!(byte, 0x01..=0x7f)
     }
@@ -40,7 +39,6 @@ pub mod indicators {
     /// Controls
     ///
     /// CTL = %x00-1F / %x7F
-    #[allow(non_snake_case)]
     pub fn is_ctl(byte: u8) -> bool {
         matches!(byte, 0x00..=0x1f | 0x7f)
     }

--- a/imap-types/src/utils.rs
+++ b/imap-types/src/utils.rs
@@ -122,7 +122,6 @@ pub fn escape_quoted(unescaped: &str) -> Cow<str> {
     escaped
 }
 
-#[allow(unused)]
 pub fn unescape_quoted(escaped: &str) -> Cow<str> {
     let mut unescaped = Cow::Borrowed(escaped);
 

--- a/imap-types/src/utils.rs
+++ b/imap-types/src/utils.rs
@@ -1,5 +1,8 @@
+//! Functions that may come in handy.
+
 use std::borrow::Cow;
 
+/// Converts bytes into a ready-to-be-printed form.
 pub fn escape_byte_string<B>(bytes: B) -> String
 where
     B: AsRef<[u8]>,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::auth`].
+
 #[cfg(not(feature = "quirk_crlf_relaxed"))]
 use abnf_core::streaming::crlf;
 #[cfg(feature = "quirk_crlf_relaxed")]

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::body`].
+
 use abnf_core::streaming::sp;
 /// Re-export everything from imap-types.
 pub use imap_types::body::*;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,4 +1,4 @@
-//! # Serialization of messages
+//! # (De)serialization of messages.
 //!
 //! All messages implement the `Encode` trait.
 //! You can `use imap_codec::Encode` and call the `.encode()` (or `.encode().dump()`) method to serialize a message.

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::command`].
+
 #[cfg(feature = "ext_sasl_ir")]
 use std::borrow::Cow;
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::core`].
+
 use std::{borrow::Cow, num::NonZeroU32, str::from_utf8};
 
 #[cfg(not(feature = "quirk_crlf_relaxed"))]

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::datetime`].
+
 use abnf_core::{
     is_digit,
     streaming::{dquote, sp},

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::envelope`].
+
 use abnf_core::streaming::sp;
 /// Re-export everything from imap-types.
 pub use imap_types::envelope::*;

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::extensions`].
+
 #[cfg(feature = "ext_compress")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ext_compress")))]
 pub mod compress;

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::fetch`].
+
 use std::num::NonZeroU32;
 
 use abnf_core::streaming::sp;

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::flag`].
+
 use abnf_core::streaming::sp;
 /// Re-export everything from imap-types.
 pub use imap_types::flag::*;

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::mailbox`].
+
 use abnf_core::streaming::{dquote, sp};
 /// Re-export everything from imap-types.
 pub use imap_types::mailbox::*;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::response`].
+
 use std::str::from_utf8;
 
 #[cfg(not(feature = "quirk_crlf_relaxed"))]

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::search`].
+
 use abnf_core::streaming::sp;
 /// Re-export everything from imap-types.
 pub use imap_types::search::*;

--- a/src/section.rs
+++ b/src/section.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::section`].
+
 use std::num::NonZeroU32;
 
 use abnf_core::streaming::sp;

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::sequence`].
+
 /// Re-export everything from imap-types.
 pub use imap_types::sequence::*;
 use nom::{

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,3 +1,5 @@
+//! Please refer to [`imap_types::status`].
+
 use abnf_core::streaming::sp;
 /// Re-export everything from imap-types.
 pub use imap_types::status::*;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,3 +1,5 @@
+//! Support for tokio and (tokio_util::codec).
+
 use thiserror::Error;
 
 pub mod client;


### PR DESCRIPTION
This closes #265 and #267 (for now).