### PR TITLE
chore: Don't export nom parsers.

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -19,7 +19,7 @@ use crate::{
 /// `auth-type = atom`
 ///
 /// Note: Defined by \[SASL\]
-pub fn auth_type(input: &[u8]) -> IMAPResult<&[u8], AuthMechanism> {
+pub(crate) fn auth_type(input: &[u8]) -> IMAPResult<&[u8], AuthMechanism> {
     let (rem, atom) = atom(input)?;
 
     Ok((rem, AuthMechanism::from(atom)))
@@ -35,7 +35,7 @@ pub fn auth_type(input: &[u8]) -> IMAPResult<&[u8], AuthMechanism> {
 ///                CRLF is additionally parsed in this parser.
 ///                FIXME: Multiline base64 currently does not work.
 /// ```
-pub fn authenticate_data(input: &[u8]) -> IMAPResult<&[u8], AuthenticateData> {
+pub(crate) fn authenticate_data(input: &[u8]) -> IMAPResult<&[u8], AuthenticateData> {
     map(terminated(base64, crlf), |data| {
         AuthenticateData(Secret::new(data))
     })(input) // FIXME: many0 deleted

--- a/src/codec/decode.rs
+++ b/src/codec/decode.rs
@@ -12,18 +12,19 @@ use crate::{
 };
 
 /// An extended version of [`nom::IResult`].
-pub type IMAPResult<I, O> = Result<(I, O), nom::Err<IMAPParseError<I>>>;
+pub(crate) type IMAPResult<I, O> = Result<(I, O), nom::Err<IMAPParseError<I>>>;
 
 /// An extended version of [`nom::error::Error`].
 #[derive(Debug)]
-pub struct IMAPParseError<I> {
+pub(crate) struct IMAPParseError<I> {
+    #[allow(unused)]
     pub input: I,
     pub kind: IMAPErrorKind,
 }
 
 /// An extended version of [`nom::error::ErrorKind`].
 #[derive(Debug)]
-pub enum IMAPErrorKind {
+pub(crate) enum IMAPErrorKind {
     Literal {
         length: u32,
         #[cfg(feature = "ext_literal")]

--- a/src/command.rs
+++ b/src/command.rs
@@ -50,7 +50,7 @@ use crate::{
 ///                     command-nonauth /
 ///                     command-select
 ///                   ) CRLF`
-pub fn command(input: &[u8]) -> IMAPResult<&[u8], Command> {
+pub(crate) fn command(input: &[u8]) -> IMAPResult<&[u8], Command> {
     let mut parser = tuple((
         tag_imap,
         sp,
@@ -68,7 +68,7 @@ pub fn command(input: &[u8]) -> IMAPResult<&[u8], Command> {
 /// `command-any = "CAPABILITY" / "LOGOUT" / "NOOP" / x-command`
 ///
 /// Note: Valid in all states
-pub fn command_any(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn command_any(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     alt((
         value(CommandBody::Capability, tag_no_case(b"CAPABILITY")),
         value(CommandBody::Logout, tag_no_case(b"LOGOUT")),
@@ -95,7 +95,7 @@ pub fn command_any(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 ///                 compress ; RFC 4978`
 ///
 /// Note: Valid only in Authenticated or Selected state
-pub fn command_auth(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn command_auth(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     alt((
         append,
         create,
@@ -124,7 +124,7 @@ pub fn command_auth(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `append = "APPEND" SP mailbox [SP flag-list] [SP date-time] SP literal`
-pub fn append(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn append(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((
         tag_no_case(b"APPEND"),
         sp,
@@ -151,7 +151,7 @@ pub fn append(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 /// `create = "CREATE" SP mailbox`
 ///
 /// Note: Use of INBOX gives a NO error
-pub fn create(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn create(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"CREATE"), sp, mailbox));
 
     let (remaining, (_, _, mailbox)) = parser(input)?;
@@ -162,7 +162,7 @@ pub fn create(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 /// `delete = "DELETE" SP mailbox`
 ///
 /// Note: Use of INBOX gives a NO error
-pub fn delete(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn delete(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"DELETE"), sp, mailbox));
 
     let (remaining, (_, _, mailbox)) = parser(input)?;
@@ -171,7 +171,7 @@ pub fn delete(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `examine = "EXAMINE" SP mailbox`
-pub fn examine(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn examine(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"EXAMINE"), sp, mailbox));
 
     let (remaining, (_, _, mailbox)) = parser(input)?;
@@ -180,7 +180,7 @@ pub fn examine(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `list = "LIST" SP mailbox SP list-mailbox`
-pub fn list(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn list(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"LIST"), sp, mailbox, sp, list_mailbox));
 
     let (remaining, (_, _, reference, _, mailbox_wildcard)) = parser(input)?;
@@ -195,7 +195,7 @@ pub fn list(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `lsub = "LSUB" SP mailbox SP list-mailbox`
-pub fn lsub(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn lsub(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"LSUB"), sp, mailbox, sp, list_mailbox));
 
     let (remaining, (_, _, reference, _, mailbox_wildcard)) = parser(input)?;
@@ -212,7 +212,7 @@ pub fn lsub(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 /// `rename = "RENAME" SP mailbox SP mailbox`
 ///
 /// Note: Use of INBOX as a destination gives a NO error
-pub fn rename(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn rename(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"RENAME"), sp, mailbox, sp, mailbox));
 
     let (remaining, (_, _, mailbox, _, new_mailbox)) = parser(input)?;
@@ -227,7 +227,7 @@ pub fn rename(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `select = "SELECT" SP mailbox`
-pub fn select(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn select(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"SELECT"), sp, mailbox));
 
     let (remaining, (_, _, mailbox)) = parser(input)?;
@@ -236,7 +236,7 @@ pub fn select(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `status = "STATUS" SP mailbox SP "(" status-att *(SP status-att) ")"`
-pub fn status(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn status(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((
         tag_no_case(b"STATUS"),
         sp,
@@ -257,7 +257,7 @@ pub fn status(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `subscribe = "SUBSCRIBE" SP mailbox`
-pub fn subscribe(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn subscribe(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"SUBSCRIBE"), sp, mailbox));
 
     let (remaining, (_, _, mailbox)) = parser(input)?;
@@ -266,7 +266,7 @@ pub fn subscribe(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `unsubscribe = "UNSUBSCRIBE" SP mailbox`
-pub fn unsubscribe(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn unsubscribe(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"UNSUBSCRIBE"), sp, mailbox));
 
     let (remaining, (_, _, mailbox)) = parser(input)?;
@@ -279,7 +279,7 @@ pub fn unsubscribe(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 /// `command-nonauth = login / authenticate / "STARTTLS"`
 ///
 /// Note: Valid only when in Not Authenticated state
-pub fn command_nonauth(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn command_nonauth(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = alt((
         login,
         #[cfg(not(feature = "ext_sasl_ir"))]
@@ -303,7 +303,7 @@ pub fn command_nonauth(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `login = "LOGIN" SP userid SP password`
-pub fn login(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn login(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"LOGIN"), sp, userid, sp, password));
 
     let (remaining, (_, _, username, _, password)) = parser(input)?;
@@ -319,13 +319,13 @@ pub fn login(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 
 #[inline]
 /// `userid = astring`
-pub fn userid(input: &[u8]) -> IMAPResult<&[u8], AString> {
+pub(crate) fn userid(input: &[u8]) -> IMAPResult<&[u8], AString> {
     astring(input)
 }
 
 #[inline]
 /// `password = astring`
-pub fn password(input: &[u8]) -> IMAPResult<&[u8], AString> {
+pub(crate) fn password(input: &[u8]) -> IMAPResult<&[u8], AString> {
     astring(input)
 }
 
@@ -339,7 +339,7 @@ pub fn password(input: &[u8]) -> IMAPResult<&[u8], AString> {
 ///                CRLF is parsed by upper command parser.
 /// ```
 #[cfg(not(feature = "ext_sasl_ir"))]
-pub fn authenticate(input: &[u8]) -> IMAPResult<&[u8], AuthMechanism> {
+pub(crate) fn authenticate(input: &[u8]) -> IMAPResult<&[u8], AuthMechanism> {
     let mut parser = preceded(tag_no_case(b"AUTHENTICATE "), auth_type);
 
     let (remaining, auth_type) = parser(input)?;
@@ -364,7 +364,7 @@ pub fn authenticate(input: &[u8]) -> IMAPResult<&[u8], AuthMechanism> {
 #[cfg(feature = "ext_sasl_ir")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ext_sasl_ir")))]
 #[allow(clippy::type_complexity)]
-pub fn authenticate_sasl_ir(
+pub(crate) fn authenticate_sasl_ir(
     input: &[u8],
 ) -> IMAPResult<&[u8], (AuthMechanism, Option<Secret<Cow<[u8]>>>)> {
     let mut parser = tuple((
@@ -398,7 +398,7 @@ pub fn authenticate_sasl_ir(
 ///                   search`
 ///
 /// Note: Valid only when in Selected state
-pub fn command_select(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn command_select(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     alt((
         value(CommandBody::Check, tag_no_case(b"CHECK")),
         value(CommandBody::Close, tag_no_case(b"CLOSE")),
@@ -416,7 +416,7 @@ pub fn command_select(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `copy = "COPY" SP sequence-set SP mailbox`
-pub fn copy(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn copy(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"COPY"), sp, sequence_set, sp, mailbox));
 
     let (remaining, (_, _, sequence_set, _, mailbox)) = parser(input)?;
@@ -435,7 +435,7 @@ pub fn copy(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 ///                                      "FULL" /
 ///                                      "FAST" /
 ///                                      fetch-att / "(" fetch-att *(SP fetch-att) ")")`
-pub fn fetch(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn fetch(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((
         tag_no_case(b"FETCH"),
         sp,
@@ -477,7 +477,7 @@ pub fn fetch(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `store = "STORE" SP sequence-set SP store-att-flags`
-pub fn store(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn store(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"STORE"), sp, sequence_set, sp, store_att_flags));
 
     let (remaining, (_, _, sequence_set, _, (kind, response, flags))) = parser(input)?;
@@ -495,7 +495,9 @@ pub fn store(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 }
 
 /// `store-att-flags = (["+" / "-"] "FLAGS" [".SILENT"]) SP (flag-list / (flag *(SP flag)))`
-pub fn store_att_flags(input: &[u8]) -> IMAPResult<&[u8], (StoreType, StoreResponse, Vec<Flag>)> {
+pub(crate) fn store_att_flags(
+    input: &[u8],
+) -> IMAPResult<&[u8], (StoreType, StoreResponse, Vec<Flag>)> {
     let mut parser = tuple((
         tuple((
             map(
@@ -526,7 +528,7 @@ pub fn store_att_flags(input: &[u8]) -> IMAPResult<&[u8], (StoreType, StoreRespo
 /// `uid = "UID" SP (copy / fetch / search / store)`
 ///
 /// Note: Unique identifiers used instead of message sequence numbers
-pub fn uid(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn uid(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((
         tag_no_case(b"UID"),
         sp,

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -22,14 +22,14 @@ use crate::codec::{IMAPErrorKind, IMAPParseError, IMAPResult};
 /// ```abnf
 /// date = date-text / DQUOTE date-text DQUOTE
 /// ```
-pub fn date(input: &[u8]) -> IMAPResult<&[u8], Option<NaiveDate>> {
+pub(crate) fn date(input: &[u8]) -> IMAPResult<&[u8], Option<NaiveDate>> {
     alt((date_text, delimited(dquote, date_text, dquote)))(input)
 }
 
 /// ```abnf
 /// date-text = date-day "-" date-month "-" date-year
 /// ```
-pub fn date_text(input: &[u8]) -> IMAPResult<&[u8], Option<NaiveDate>> {
+pub(crate) fn date_text(input: &[u8]) -> IMAPResult<&[u8], Option<NaiveDate>> {
     let mut parser = tuple((date_day, tag(b"-"), date_month, tag(b"-"), date_year));
 
     let (remaining, (d, _, m, _, y)) = parser(input)?;
@@ -45,7 +45,7 @@ pub fn date_text(input: &[u8]) -> IMAPResult<&[u8], Option<NaiveDate>> {
 /// ```abnf
 /// date-day = 1*2DIGIT
 /// ```
-pub fn date_day(input: &[u8]) -> IMAPResult<&[u8], u8> {
+pub(crate) fn date_day(input: &[u8]) -> IMAPResult<&[u8], u8> {
     digit_1_2(input)
 }
 
@@ -54,7 +54,7 @@ pub fn date_day(input: &[u8]) -> IMAPResult<&[u8], u8> {
 ///              "May" / "Jun" / "Jul" / "Aug" /
 ///              "Sep" / "Oct" / "Nov" / "Dec"
 /// ```
-pub fn date_month(input: &[u8]) -> IMAPResult<&[u8], u8> {
+pub(crate) fn date_month(input: &[u8]) -> IMAPResult<&[u8], u8> {
     alt((
         value(1, tag_no_case(b"Jan")),
         value(2, tag_no_case(b"Feb")),
@@ -74,7 +74,7 @@ pub fn date_month(input: &[u8]) -> IMAPResult<&[u8], u8> {
 /// ```abnf
 /// date-year = 4DIGIT
 /// ```
-pub fn date_year(input: &[u8]) -> IMAPResult<&[u8], u16> {
+pub(crate) fn date_year(input: &[u8]) -> IMAPResult<&[u8], u16> {
     digit_4(input)
 }
 
@@ -83,7 +83,7 @@ pub fn date_year(input: &[u8]) -> IMAPResult<&[u8], u16> {
 /// ```abnf
 /// time = 2DIGIT ":" 2DIGIT ":" 2DIGIT
 /// ```
-pub fn time(input: &[u8]) -> IMAPResult<&[u8], Option<NaiveTime>> {
+pub(crate) fn time(input: &[u8]) -> IMAPResult<&[u8], Option<NaiveTime>> {
     let mut parser = tuple((digit_2, tag(b":"), digit_2, tag(b":"), digit_2));
 
     let (remaining, (h, _, m, _, s)) = parser(input)?;
@@ -101,7 +101,7 @@ pub fn time(input: &[u8]) -> IMAPResult<&[u8], Option<NaiveTime>> {
 ///              zone
 ///             DQUOTE
 /// ```
-pub fn date_time(input: &[u8]) -> IMAPResult<&[u8], DateTime> {
+pub(crate) fn date_time(input: &[u8]) -> IMAPResult<&[u8], DateTime> {
     let mut parser = delimited(
         dquote,
         tuple((
@@ -147,7 +147,7 @@ pub fn date_time(input: &[u8]) -> IMAPResult<&[u8], DateTime> {
 /// ```abnf
 /// date-day-fixed = (SP DIGIT) / 2DIGIT
 /// ```
-pub fn date_day_fixed(input: &[u8]) -> IMAPResult<&[u8], u8> {
+pub(crate) fn date_day_fixed(input: &[u8]) -> IMAPResult<&[u8], u8> {
     alt((
         map(
             preceded(sp, take_while_m_n(1, 1, is_digit)),
@@ -166,7 +166,7 @@ pub fn date_day_fixed(input: &[u8]) -> IMAPResult<&[u8], u8> {
 /// ```abnf
 /// zone = ("+" / "-") 4DIGIT
 /// ```
-pub fn zone(input: &[u8]) -> IMAPResult<&[u8], Option<FixedOffset>> {
+pub(crate) fn zone(input: &[u8]) -> IMAPResult<&[u8], Option<FixedOffset>> {
     let mut parser = tuple((alt((char('+'), char('-'))), digit_2, digit_2));
 
     let (remaining, (sign, hh, mm)) = parser(input)?;

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -30,7 +30,7 @@ use crate::{
 ///              env-message-id
 ///            ")"
 /// ```
-pub fn envelope(input: &[u8]) -> IMAPResult<&[u8], Envelope> {
+pub(crate) fn envelope(input: &[u8]) -> IMAPResult<&[u8], Envelope> {
     let mut parser = delimited(
         tag(b"("),
         tuple((
@@ -101,18 +101,18 @@ pub fn envelope(input: &[u8]) -> IMAPResult<&[u8], Envelope> {
 
 #[inline]
 /// `env-date = nstring`
-pub fn env_date(input: &[u8]) -> IMAPResult<&[u8], NString> {
+pub(crate) fn env_date(input: &[u8]) -> IMAPResult<&[u8], NString> {
     nstring(input)
 }
 
 #[inline]
 /// `env-subject = nstring`
-pub fn env_subject(input: &[u8]) -> IMAPResult<&[u8], NString> {
+pub(crate) fn env_subject(input: &[u8]) -> IMAPResult<&[u8], NString> {
     nstring(input)
 }
 
 /// `env-from = "(" 1*address ")" / nil`
-pub fn env_from(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
+pub(crate) fn env_from(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
     alt((
         delimited(tag(b"("), many1(address), tag(b")")),
         map(nil, |_| Vec::new()),
@@ -120,7 +120,7 @@ pub fn env_from(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
 }
 
 /// `env-sender = "(" 1*address ")" / nil`
-pub fn env_sender(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
+pub(crate) fn env_sender(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
     alt((
         delimited(tag(b"("), many1(address), tag(b")")),
         map(nil, |_| Vec::new()),
@@ -128,7 +128,7 @@ pub fn env_sender(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
 }
 
 /// `env-reply-to = "(" 1*address ")" / nil`
-pub fn env_reply_to(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
+pub(crate) fn env_reply_to(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
     alt((
         delimited(tag(b"("), many1(address), tag(b")")),
         map(nil, |_| Vec::new()),
@@ -136,7 +136,7 @@ pub fn env_reply_to(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
 }
 
 /// `env-to = "(" 1*address ")" / nil`
-pub fn env_to(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
+pub(crate) fn env_to(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
     alt((
         delimited(tag(b"("), many1(address), tag(b")")),
         map(nil, |_| Vec::new()),
@@ -144,7 +144,7 @@ pub fn env_to(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
 }
 
 /// `env-cc = "(" 1*address ")" / nil`
-pub fn env_cc(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
+pub(crate) fn env_cc(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
     alt((
         delimited(tag(b"("), many1(address), tag(b")")),
         map(nil, |_| Vec::new()),
@@ -152,7 +152,7 @@ pub fn env_cc(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
 }
 
 /// `env-bcc = "(" 1*address ")" / nil`
-pub fn env_bcc(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
+pub(crate) fn env_bcc(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
     alt((
         delimited(tag(b"("), many1(address), tag(b")")),
         map(nil, |_| Vec::new()),
@@ -161,13 +161,13 @@ pub fn env_bcc(input: &[u8]) -> IMAPResult<&[u8], Vec<Address>> {
 
 #[inline]
 /// `env-in-reply-to = nstring`
-pub fn env_in_reply_to(input: &[u8]) -> IMAPResult<&[u8], NString> {
+pub(crate) fn env_in_reply_to(input: &[u8]) -> IMAPResult<&[u8], NString> {
     nstring(input)
 }
 
 #[inline]
 /// `env-message-id = nstring`
-pub fn env_message_id(input: &[u8]) -> IMAPResult<&[u8], NString> {
+pub(crate) fn env_message_id(input: &[u8]) -> IMAPResult<&[u8], NString> {
     nstring(input)
 }
 
@@ -177,7 +177,7 @@ pub fn env_message_id(input: &[u8]) -> IMAPResult<&[u8], NString> {
 ///             addr-mailbox SP
 ///             addr-host
 ///             ")"`
-pub fn address(input: &[u8]) -> IMAPResult<&[u8], Address> {
+pub(crate) fn address(input: &[u8]) -> IMAPResult<&[u8], Address> {
     let mut parser = delimited(
         tag(b"("),
         tuple((addr_name, sp, addr_adl, sp, addr_mailbox, sp, addr_host)),
@@ -203,7 +203,7 @@ pub fn address(input: &[u8]) -> IMAPResult<&[u8], Address> {
 /// If non-NIL, holds phrase from [RFC-2822]
 /// mailbox after removing [RFC-2822] quoting
 /// TODO(misuse): use `Phrase`?
-pub fn addr_name(input: &[u8]) -> IMAPResult<&[u8], NString> {
+pub(crate) fn addr_name(input: &[u8]) -> IMAPResult<&[u8], NString> {
     nstring(input)
 }
 
@@ -212,7 +212,7 @@ pub fn addr_name(input: &[u8]) -> IMAPResult<&[u8], NString> {
 ///
 /// Holds route from [RFC-2822] route-addr if non-NIL
 /// TODO(misuse): use `Route`?
-pub fn addr_adl(input: &[u8]) -> IMAPResult<&[u8], NString> {
+pub(crate) fn addr_adl(input: &[u8]) -> IMAPResult<&[u8], NString> {
     nstring(input)
 }
 
@@ -223,7 +223,7 @@ pub fn addr_adl(input: &[u8]) -> IMAPResult<&[u8], NString> {
 /// if non-NIL and addr-host is NIL, holds [RFC-2822] group name.
 /// Otherwise, holds [RFC-2822] local-part after removing [RFC-2822] quoting
 /// TODO(misuse): use `GroupName` or `LocalPart`?
-pub fn addr_mailbox(input: &[u8]) -> IMAPResult<&[u8], NString> {
+pub(crate) fn addr_mailbox(input: &[u8]) -> IMAPResult<&[u8], NString> {
     nstring(input)
 }
 
@@ -233,7 +233,7 @@ pub fn addr_mailbox(input: &[u8]) -> IMAPResult<&[u8], NString> {
 /// NIL indicates [RFC-2822] group syntax.
 /// Otherwise, holds [RFC-2822] domain name
 /// TODO(misuse): use `DomainName`?
-pub fn addr_host(input: &[u8]) -> IMAPResult<&[u8], NString> {
+pub(crate) fn addr_host(input: &[u8]) -> IMAPResult<&[u8], NString> {
     nstring(input)
 }
 

--- a/src/extensions/compress.rs
+++ b/src/extensions/compress.rs
@@ -22,12 +22,12 @@ use crate::{
 };
 
 /// `algorithm = "DEFLATE"`
-pub fn algorithm(input: &[u8]) -> IMAPResult<&[u8], CompressionAlgorithm> {
+pub(crate) fn algorithm(input: &[u8]) -> IMAPResult<&[u8], CompressionAlgorithm> {
     value(CompressionAlgorithm::Deflate, tag_no_case("DEFLATE"))(input)
 }
 
 /// `compress = "COMPRESS" SP algorithm`
-pub fn compress(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn compress(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     map(preceded(tag_no_case("COMPRESS "), algorithm), |algorithm| {
         CommandBody::Compress { algorithm }
     })(input)

--- a/src/extensions/enable.rs
+++ b/src/extensions/enable.rs
@@ -36,7 +36,7 @@ use crate::{
 ///
 /// command-any =/ enable
 /// ```
-pub fn enable(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn enable(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((
         tag_no_case("ENABLE"),
         many1(preceded(sp, capability_enable)),
@@ -52,12 +52,12 @@ pub fn enable(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     ))
 }
 
-pub fn capability_enable(input: &[u8]) -> IMAPResult<&[u8], CapabilityEnable> {
+pub(crate) fn capability_enable(input: &[u8]) -> IMAPResult<&[u8], CapabilityEnable> {
     map(atom, CapabilityEnable::from)(input)
 }
 
 /// `enable-data = "ENABLED" *(SP capability)`
-pub fn enable_data(input: &[u8]) -> IMAPResult<&[u8], Data> {
+pub(crate) fn enable_data(input: &[u8]) -> IMAPResult<&[u8], Data> {
     let mut parser = tuple((
         tag_no_case(b"ENABLED"),
         many0(preceded(sp, capability_enable)),

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -33,7 +33,7 @@ use crate::{
 /// ```
 ///
 /// Valid only in Authenticated or Selected state
-pub fn idle(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn idle(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     value(CommandBody::Idle, tag_no_case("IDLE"))(input)
 }
 
@@ -51,7 +51,7 @@ pub fn idle(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 ///
 /// Note: This parser must be executed *instead* of the command parser
 /// when the server is in the IDLE state.
-pub fn idle_done(input: &[u8]) -> IMAPResult<&[u8], IdleDone> {
+pub(crate) fn idle_done(input: &[u8]) -> IMAPResult<&[u8], IdleDone> {
     value(IdleDone, tuple((tag_no_case("DONE"), crlf)))(input)
 }
 

--- a/src/extensions/move.rs
+++ b/src/extensions/move.rs
@@ -10,7 +10,7 @@ use crate::{codec::IMAPResult, command::CommandBody, mailbox::mailbox, sequence:
 /// ```abnf
 /// move = "MOVE" SP sequence-set SP mailbox
 /// ```
-pub fn r#move(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn r#move(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case(b"MOVE"), sp, sequence_set, sp, mailbox));
 
     let (remaining, (_, _, sequence_set, _, mailbox)) = parser(input)?;

--- a/src/extensions/quota.rs
+++ b/src/extensions/quota.rs
@@ -24,7 +24,7 @@ use crate::{
 /// quota-root-name = astring
 /// ```
 #[inline]
-pub fn quota_root_name(input: &[u8]) -> IMAPResult<&[u8], AString> {
+pub(crate) fn quota_root_name(input: &[u8]) -> IMAPResult<&[u8], AString> {
     astring(input)
 }
 
@@ -32,7 +32,7 @@ pub fn quota_root_name(input: &[u8]) -> IMAPResult<&[u8], AString> {
 /// getquota = "GETQUOTA" SP quota-root-name
 /// ```
 #[inline]
-pub fn getquota(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn getquota(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case("GETQUOTA "), quota_root_name));
 
     let (remaining, (_, root)) = parser(input)?;
@@ -43,7 +43,7 @@ pub fn getquota(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 /// ```abnf
 /// getquotaroot = "GETQUOTAROOT" SP mailbox
 /// ```
-pub fn getquotaroot(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn getquotaroot(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((tag_no_case("GETQUOTAROOT "), mailbox));
 
     let (remaining, (_, mailbox)) = parser(input)?;
@@ -60,7 +60,7 @@ pub fn getquotaroot(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 ///
 /// resource-limit = number64
 /// ```
-pub fn quota_resource(input: &[u8]) -> IMAPResult<&[u8], QuotaGet> {
+pub(crate) fn quota_resource(input: &[u8]) -> IMAPResult<&[u8], QuotaGet> {
     let mut parser = tuple((resource_name, sp, number64, sp, number64));
 
     let (remaining, (resource, _, usage, _, limit)) = parser(input)?;
@@ -84,7 +84,7 @@ pub fn quota_resource(input: &[u8]) -> IMAPResult<&[u8], QuotaGet> {
 ///
 /// resource-name-ext = atom
 /// ```
-pub fn resource_name(input: &[u8]) -> IMAPResult<&[u8], Resource> {
+pub(crate) fn resource_name(input: &[u8]) -> IMAPResult<&[u8], Resource> {
     map(atom, Resource::from)(input)
 }
 
@@ -93,7 +93,7 @@ pub fn resource_name(input: &[u8]) -> IMAPResult<&[u8], Resource> {
 ///
 /// quota-list = "(" quota-resource *(SP quota-resource) ")"
 /// ```
-pub fn quota_response(input: &[u8]) -> IMAPResult<&[u8], Data> {
+pub(crate) fn quota_response(input: &[u8]) -> IMAPResult<&[u8], Data> {
     let mut parser = tuple((
         tag_no_case("QUOTA "),
         quota_root_name,
@@ -116,7 +116,7 @@ pub fn quota_response(input: &[u8]) -> IMAPResult<&[u8], Data> {
 /// ```abnf
 /// quotaroot-response = "QUOTAROOT" SP mailbox *(SP quota-root-name)
 /// ```
-pub fn quotaroot_response(input: &[u8]) -> IMAPResult<&[u8], Data> {
+pub(crate) fn quotaroot_response(input: &[u8]) -> IMAPResult<&[u8], Data> {
     let mut parser = tuple((
         tag_no_case("QUOTAROOT "),
         mailbox,
@@ -133,7 +133,7 @@ pub fn quotaroot_response(input: &[u8]) -> IMAPResult<&[u8], Data> {
 ///
 /// setquota-list = "(" [setquota-resource *(SP setquota-resource)] ")"
 /// ```
-pub fn setquota(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn setquota(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((
         tag_no_case("SETQUOTA "),
         quota_root_name,
@@ -149,7 +149,7 @@ pub fn setquota(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 /// ```abnf
 /// setquota-resource = resource-name SP resource-limit
 /// ```
-pub fn setquota_resource(input: &[u8]) -> IMAPResult<&[u8], QuotaSet> {
+pub(crate) fn setquota_resource(input: &[u8]) -> IMAPResult<&[u8], QuotaSet> {
     let mut parser = tuple((resource_name, sp, number64));
 
     let (remaining, (resource, _, limit)) = parser(input)?;
@@ -169,7 +169,7 @@ pub fn setquota_resource(input: &[u8]) -> IMAPResult<&[u8], QuotaSet> {
 // /// ```abnf
 // /// capability-quota = "QUOTASET" / capa-quota-res / "QUOTA"
 // /// ```
-// pub fn capability_quota(input: &[u8]) -> IMAPResult<&[u8], Capability> {
+// pub(crate) fn capability_quota(input: &[u8]) -> IMAPResult<&[u8], Capability> {
 //     alt((
 //         value(Capability::QuotaSet, tag_no_case("QUOTASET")),
 //         capa_quota_res,
@@ -180,7 +180,7 @@ pub fn setquota_resource(input: &[u8]) -> IMAPResult<&[u8], QuotaSet> {
 // /// ```abnf
 // /// capa-quota-res = "QUOTA=RES-" resource-name
 // /// ```
-// pub fn capa_quota_res(input: &[u8]) -> IMAPResult<&[u8], Capability> {
+// pub(crate) fn capa_quota_res(input: &[u8]) -> IMAPResult<&[u8], Capability> {
 //     let mut parser = preceded(tag_no_case("QUOTA=RES-"), resource_name);
 //
 //     let (remaining, resource) = parser(input)?;

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -31,7 +31,7 @@ use crate::{
 ///              "UID" /
 ///              "BODY" section ["<" number "." nz-number ">"] /
 ///              "BODY.PEEK" section ["<" number "." nz-number ">"]`
-pub fn fetch_att(input: &[u8]) -> IMAPResult<&[u8], MessageDataItemName> {
+pub(crate) fn fetch_att(input: &[u8]) -> IMAPResult<&[u8], MessageDataItemName> {
     alt((
         value(MessageDataItemName::Envelope, tag_no_case(b"ENVELOPE")),
         value(MessageDataItemName::Flags, tag_no_case(b"FLAGS")),
@@ -90,7 +90,7 @@ pub fn fetch_att(input: &[u8]) -> IMAPResult<&[u8], MessageDataItemName> {
 /// `msg-att = "("
 ///            (msg-att-dynamic / msg-att-static) *(SP (msg-att-dynamic / msg-att-static))
 ///            ")"`
-pub fn msg_att(input: &[u8]) -> IMAPResult<&[u8], NonEmptyVec<MessageDataItem>> {
+pub(crate) fn msg_att(input: &[u8]) -> IMAPResult<&[u8], NonEmptyVec<MessageDataItem>> {
     delimited(
         tag(b"("),
         map(
@@ -104,7 +104,7 @@ pub fn msg_att(input: &[u8]) -> IMAPResult<&[u8], NonEmptyVec<MessageDataItem>> 
 /// `msg-att-dynamic = "FLAGS" SP "(" [flag-fetch *(SP flag-fetch)] ")"`
 ///
 /// Note: MAY change for a message
-pub fn msg_att_dynamic(input: &[u8]) -> IMAPResult<&[u8], MessageDataItem> {
+pub(crate) fn msg_att_dynamic(input: &[u8]) -> IMAPResult<&[u8], MessageDataItem> {
     let mut parser = tuple((
         tag_no_case(b"FLAGS"),
         sp,
@@ -125,7 +125,7 @@ pub fn msg_att_dynamic(input: &[u8]) -> IMAPResult<&[u8], MessageDataItem> {
 ///                   "UID" SP uniqueid`
 ///
 /// Note: MUST NOT change for a message
-pub fn msg_att_static(input: &[u8]) -> IMAPResult<&[u8], MessageDataItem> {
+pub(crate) fn msg_att_static(input: &[u8]) -> IMAPResult<&[u8], MessageDataItem> {
     alt((
         map(
             tuple((tag_no_case(b"ENVELOPE"), sp, envelope)),
@@ -183,7 +183,7 @@ pub fn msg_att_static(input: &[u8]) -> IMAPResult<&[u8], MessageDataItem> {
 /// `uniqueid = nz-number`
 ///
 /// Note: Strictly ascending
-pub fn uniqueid(input: &[u8]) -> IMAPResult<&[u8], NonZeroU32> {
+pub(crate) fn uniqueid(input: &[u8]) -> IMAPResult<&[u8], NonZeroU32> {
     nz_number(input)
 }
 

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -25,7 +25,7 @@ use crate::{codec::IMAPResult, core::atom};
 /// ```
 ///
 /// Note: Does not include "\Recent"
-pub fn flag(input: &[u8]) -> IMAPResult<&[u8], Flag> {
+pub(crate) fn flag(input: &[u8]) -> IMAPResult<&[u8], Flag> {
     alt((
         map(preceded(char('\\'), atom), Flag::system_or_extension),
         map(atom, Flag::Keyword),
@@ -35,7 +35,7 @@ pub fn flag(input: &[u8]) -> IMAPResult<&[u8], Flag> {
 // Note(duesee): This was inlined into [`flag`].
 // #[inline]
 // /// `flag-keyword = atom`
-// pub fn flag_keyword(input: &[u8]) -> IMAPResult<&[u8], Flag> {
+// pub(crate) fn flag_keyword(input: &[u8]) -> IMAPResult<&[u8], Flag> {
 //     map(atom, Flag::Keyword)(input)
 // }
 
@@ -49,17 +49,17 @@ pub fn flag(input: &[u8]) -> IMAPResult<&[u8], Flag> {
 // /// Client implementations MUST accept flag-extension flags.
 // /// Server implementations MUST NOT generate flag-extension flags
 // /// except as defined by future standard or standards-track revisions of this specification.
-// pub fn flag_extension(input: &[u8]) -> IMAPResult<&[u8], Atom> {
+// pub(crate) fn flag_extension(input: &[u8]) -> IMAPResult<&[u8], Atom> {
 //     preceded(tag(b"\\"), atom)(input)
 // }
 
 /// `flag-list = "(" [flag *(SP flag)] ")"`
-pub fn flag_list(input: &[u8]) -> IMAPResult<&[u8], Vec<Flag>> {
+pub(crate) fn flag_list(input: &[u8]) -> IMAPResult<&[u8], Vec<Flag>> {
     delimited(tag(b"("), separated_list0(sp, flag), tag(b")"))(input)
 }
 
 /// `flag-fetch = flag / "\Recent"`
-pub fn flag_fetch(input: &[u8]) -> IMAPResult<&[u8], FlagFetch> {
+pub(crate) fn flag_fetch(input: &[u8]) -> IMAPResult<&[u8], FlagFetch> {
     if let Ok((rem, peek)) = recognize(tuple((char('\\'), atom)))(input) {
         if peek.to_ascii_lowercase() == b"\\recent" {
             return Ok((rem, FlagFetch::Recent));
@@ -70,7 +70,7 @@ pub fn flag_fetch(input: &[u8]) -> IMAPResult<&[u8], FlagFetch> {
 }
 
 /// `flag-perm = flag / "\*"`
-pub fn flag_perm(input: &[u8]) -> IMAPResult<&[u8], FlagPerm> {
+pub(crate) fn flag_perm(input: &[u8]) -> IMAPResult<&[u8], FlagPerm> {
     alt((
         value(FlagPerm::AllowNewKeywords, tag("\\*")),
         map(flag, FlagPerm::Flag),
@@ -84,7 +84,7 @@ pub fn flag_perm(input: &[u8]) -> IMAPResult<&[u8], FlagPerm> {
 ///
 /// TODO(#155): ABNF enforces that sflag is not used more than once.
 ///             We could parse any flag and check for multiple occurrences of sflag later.
-pub fn mbx_list_flags(input: &[u8]) -> IMAPResult<&[u8], Vec<FlagNameAttribute>> {
+pub(crate) fn mbx_list_flags(input: &[u8]) -> IMAPResult<&[u8], Vec<FlagNameAttribute>> {
     let (remaining, flags) =
         separated_list1(sp, map(preceded(char('\\'), atom), FlagNameAttribute::from))(input)?;
 
@@ -110,7 +110,7 @@ pub fn mbx_list_flags(input: &[u8]) -> IMAPResult<&[u8], Vec<FlagNameAttribute>>
 // /// ```
 // ///
 // /// Other flags; multiple possible per LIST response
-// pub fn mbx_list_oflag(input: &[u8]) -> IMAPResult<&[u8], FlagNameAttribute> {
+// pub(crate) fn mbx_list_oflag(input: &[u8]) -> IMAPResult<&[u8], FlagNameAttribute> {
 //     alt((
 //         value(
 //             FlagNameAttribute::Noinferiors,
@@ -126,7 +126,7 @@ pub fn mbx_list_flags(input: &[u8]) -> IMAPResult<&[u8], Vec<FlagNameAttribute>>
 // /// ```
 // ///
 // /// Selectability flags; only one per LIST response
-// pub fn mbx_list_sflag(input: &[u8]) -> IMAPResult<&[u8], FlagNameAttribute> {
+// pub(crate) fn mbx_list_sflag(input: &[u8]) -> IMAPResult<&[u8], FlagNameAttribute> {
 //     alt((
 //         value(FlagNameAttribute::Noselect, tag_no_case(b"\\Noselect")),
 //         value(FlagNameAttribute::Marked, tag_no_case(b"\\Marked")),

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 /// `list-mailbox = 1*list-char / string`
-pub fn list_mailbox(input: &[u8]) -> IMAPResult<&[u8], ListMailbox> {
+pub(crate) fn list_mailbox(input: &[u8]) -> IMAPResult<&[u8], ListMailbox> {
     alt((
         map(take_while1(is_list_char), |bytes: &[u8]| {
             // # Safety
@@ -43,7 +43,7 @@ pub fn list_mailbox(input: &[u8]) -> IMAPResult<&[u8], ListMailbox> {
 }
 
 /// `list-char = ATOM-CHAR / list-wildcards / resp-specials`
-pub fn is_list_char(i: u8) -> bool {
+pub(crate) fn is_list_char(i: u8) -> bool {
     is_atom_char(i) || is_list_wildcards(i) || is_resp_specials(i)
 }
 
@@ -56,7 +56,7 @@ pub fn is_list_char(i: u8) -> bool {
 /// "I" "N" "B" "O" "X" is considered to be INBOX and not an astring.
 ///
 /// Refer to section 5.1 for further semantic details of mailbox names.
-pub fn mailbox(input: &[u8]) -> IMAPResult<&[u8], Mailbox> {
+pub(crate) fn mailbox(input: &[u8]) -> IMAPResult<&[u8], Mailbox> {
     map(astring, Mailbox::from)(input)
 }
 
@@ -67,7 +67,7 @@ pub fn mailbox(input: &[u8]) -> IMAPResult<&[u8], Mailbox> {
 ///                 "STATUS" SP mailbox SP "(" [status-att-list] ")" /
 ///                 number SP "EXISTS" /
 ///                 number SP "RECENT"`
-pub fn mailbox_data(input: &[u8]) -> IMAPResult<&[u8], Data> {
+pub(crate) fn mailbox_data(input: &[u8]) -> IMAPResult<&[u8], Data> {
     alt((
         map(
             tuple((tag_no_case(b"FLAGS"), sp, flag_list)),
@@ -125,7 +125,7 @@ pub fn mailbox_data(input: &[u8]) -> IMAPResult<&[u8], Data> {
 ///                 (DQUOTE QUOTED-CHAR DQUOTE / nil) SP
 ///                 mailbox`
 #[allow(clippy::type_complexity)]
-pub fn mailbox_list(
+pub(crate) fn mailbox_list(
     input: &[u8],
 ) -> IMAPResult<&[u8], (Option<Vec<FlagNameAttribute>>, Option<QuotedChar>, Mailbox)> {
     let mut parser = tuple((

--- a/src/search.rs
+++ b/src/search.rs
@@ -2,7 +2,7 @@
 
 use abnf_core::streaming::sp;
 /// Re-export everything from imap-types.
-pub use imap_types::search::*;
+pub(crate) use imap_types::search::*;
 use nom::{
     branch::alt,
     bytes::{complete::tag, streaming::tag_no_case},
@@ -25,7 +25,7 @@ use crate::{
 /// Note: CHARSET argument MUST be registered with IANA
 ///
 /// errata id: 261
-pub fn search(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+pub(crate) fn search(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
     let mut parser = tuple((
         tag_no_case(b"SEARCH"),
         opt(map(
@@ -94,7 +94,9 @@ pub fn search(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 ///
 /// This parser is recursively defined. Thus, in order to not overflow the stack,
 /// it is needed to limit how may recursions are allowed. (8 should suffice).
-pub fn search_key(remaining_recursions: usize) -> impl Fn(&[u8]) -> IMAPResult<&[u8], SearchKey> {
+pub(crate) fn search_key(
+    remaining_recursions: usize,
+) -> impl Fn(&[u8]) -> IMAPResult<&[u8], SearchKey> {
     move |input: &[u8]| search_key_limited(input, remaining_recursions)
 }
 

--- a/src/section.rs
+++ b/src/section.rs
@@ -19,12 +19,12 @@ use crate::{
 };
 
 /// `section = "[" [section-spec] "]"`
-pub fn section(input: &[u8]) -> IMAPResult<&[u8], Option<Section>> {
+pub(crate) fn section(input: &[u8]) -> IMAPResult<&[u8], Option<Section>> {
     delimited(tag(b"["), opt(section_spec), tag(b"]"))(input)
 }
 
 /// `section-spec = section-msgtext / (section-part ["." section-text])`
-pub fn section_spec(input: &[u8]) -> IMAPResult<&[u8], Section> {
+pub(crate) fn section_spec(input: &[u8]) -> IMAPResult<&[u8], Section> {
     alt((
         map(section_msgtext, |part_specifier| match part_specifier {
             PartSpecifier::PartNumber(_) => unreachable!(),
@@ -61,7 +61,7 @@ pub fn section_spec(input: &[u8]) -> IMAPResult<&[u8], Section> {
 /// `section-msgtext = "HEADER" / "HEADER.FIELDS" [".NOT"] SP header-list / "TEXT"`
 ///
 /// Top-level or MESSAGE/RFC822 part
-pub fn section_msgtext(input: &[u8]) -> IMAPResult<&[u8], PartSpecifier> {
+pub(crate) fn section_msgtext(input: &[u8]) -> IMAPResult<&[u8], PartSpecifier> {
     alt((
         map(
             tuple((tag_no_case(b"HEADER.FIELDS.NOT"), sp, header_list)),
@@ -80,7 +80,7 @@ pub fn section_msgtext(input: &[u8]) -> IMAPResult<&[u8], PartSpecifier> {
 /// `section-part = nz-number *("." nz-number)`
 ///
 /// Body part nesting
-pub fn section_part(input: &[u8]) -> IMAPResult<&[u8], NonEmptyVec<NonZeroU32>> {
+pub(crate) fn section_part(input: &[u8]) -> IMAPResult<&[u8], NonEmptyVec<NonZeroU32>> {
     map(
         separated_list1(tag(b"."), nz_number),
         NonEmptyVec::unvalidated,
@@ -90,7 +90,7 @@ pub fn section_part(input: &[u8]) -> IMAPResult<&[u8], NonEmptyVec<NonZeroU32>> 
 /// `section-text = section-msgtext / "MIME"`
 ///
 /// Text other than actual body part (headers, etc.)
-pub fn section_text(input: &[u8]) -> IMAPResult<&[u8], PartSpecifier> {
+pub(crate) fn section_text(input: &[u8]) -> IMAPResult<&[u8], PartSpecifier> {
     alt((
         section_msgtext,
         value(PartSpecifier::Mime, tag_no_case(b"MIME")),
@@ -98,7 +98,7 @@ pub fn section_text(input: &[u8]) -> IMAPResult<&[u8], PartSpecifier> {
 }
 
 /// `header-list = "(" header-fld-name *(SP header-fld-name) ")"`
-pub fn header_list(input: &[u8]) -> IMAPResult<&[u8], NonEmptyVec<AString>> {
+pub(crate) fn header_list(input: &[u8]) -> IMAPResult<&[u8], NonEmptyVec<AString>> {
     map(
         delimited(tag(b"("), separated_list1(sp, header_fld_name), tag(b")")),
         NonEmptyVec::unvalidated,
@@ -107,7 +107,7 @@ pub fn header_list(input: &[u8]) -> IMAPResult<&[u8], NonEmptyVec<AString>> {
 
 #[inline]
 /// `header-fld-name = astring`
-pub fn header_fld_name(input: &[u8]) -> IMAPResult<&[u8], AString> {
+pub(crate) fn header_fld_name(input: &[u8]) -> IMAPResult<&[u8], AString> {
     astring(input)
 }
 

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -34,7 +34,7 @@ use crate::{
 /// Simplified:
 ///
 /// `sequence-set = (seq-number / seq-range) *("," (seq-number / seq-range))`
-pub fn sequence_set(input: &[u8]) -> IMAPResult<&[u8], SequenceSet> {
+pub(crate) fn sequence_set(input: &[u8]) -> IMAPResult<&[u8], SequenceSet> {
     map(
         separated_list1(
             tag(b","),
@@ -56,7 +56,7 @@ pub fn sequence_set(input: &[u8]) -> IMAPResult<&[u8], SequenceSet> {
 ///
 /// Example: a unique identifier sequence range of 3291:* includes the UID
 ///          of the last message in the mailbox, even if that value is less than 3291.
-pub fn seq_range(input: &[u8]) -> IMAPResult<&[u8], (SeqOrUid, SeqOrUid)> {
+pub(crate) fn seq_range(input: &[u8]) -> IMAPResult<&[u8], (SeqOrUid, SeqOrUid)> {
     let mut parser = tuple((seq_number, tag(b":"), seq_number));
 
     let (remaining, (from, _, to)) = parser(input)?;
@@ -77,7 +77,7 @@ pub fn seq_range(input: &[u8]) -> IMAPResult<&[u8], (SeqOrUid, SeqOrUid)> {
 /// The server should respond with a tagged BAD response to a command that uses a message
 /// sequence number greater than the number of messages in the selected mailbox.
 /// This includes "*" if the selected mailbox is empty.
-pub fn seq_number(input: &[u8]) -> IMAPResult<&[u8], SeqOrUid> {
+pub(crate) fn seq_number(input: &[u8]) -> IMAPResult<&[u8], SeqOrUid> {
     alt((
         map(nz_number, SeqOrUid::Value),
         value(SeqOrUid::Asterisk, tag(b"*")),

--- a/src/status.rs
+++ b/src/status.rs
@@ -23,7 +23,7 @@ use crate::{
 ///               "UIDNEXT" /
 ///               "UIDVALIDITY" /
 ///               "UNSEEN"`
-pub fn status_att(input: &[u8]) -> IMAPResult<&[u8], StatusDataItemName> {
+pub(crate) fn status_att(input: &[u8]) -> IMAPResult<&[u8], StatusDataItemName> {
     alt((
         value(StatusDataItemName::Messages, tag_no_case(b"MESSAGES")),
         value(StatusDataItemName::Recent, tag_no_case(b"RECENT")),
@@ -48,7 +48,7 @@ pub fn status_att(input: &[u8]) -> IMAPResult<&[u8], StatusDataItemName> {
 /// `status-att-list = status-att-val *(SP status-att-val)`
 ///
 /// Note: See errata id: 261
-pub fn status_att_list(input: &[u8]) -> IMAPResult<&[u8], Vec<StatusDataItem>> {
+pub(crate) fn status_att_list(input: &[u8]) -> IMAPResult<&[u8], Vec<StatusDataItem>> {
     separated_list1(sp, status_att_val)(input)
 }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -7,7 +7,9 @@ use crate::{
     utils::escape_byte_string,
 };
 
-pub fn known_answer_test_encode((test_object, expected_bytes): (impl Encode, impl AsRef<[u8]>)) {
+pub(crate) fn known_answer_test_encode(
+    (test_object, expected_bytes): (impl Encode, impl AsRef<[u8]>),
+) {
     let expected_bytes = expected_bytes.as_ref();
     let got_bytes = test_object.encode().dump();
     let got_bytes = got_bytes.as_slice();
@@ -24,7 +26,7 @@ pub fn known_answer_test_encode((test_object, expected_bytes): (impl Encode, imp
     }
 }
 
-pub fn known_answer_test_parse<'a, O, P>(
+pub(crate) fn known_answer_test_parse<'a, O, P>(
     (test, expected_remainder, expected_object): (&'a [u8], &[u8], O),
     parser: P,
 ) where
@@ -40,7 +42,7 @@ pub fn known_answer_test_parse<'a, O, P>(
 // we tried it and failed to provide a cleaner solution. Thus, it's a macro for now.
 macro_rules! impl_kat_inverse {
     ($fn_name:ident, $object:ty) => {
-        pub fn $fn_name(tests: &[(&[u8], &[u8], $object)]) {
+        pub(crate) fn $fn_name(tests: &[(&[u8], &[u8], $object)]) {
             for (no, (test_input, expected_remainder, expected_object)) in tests.iter().enumerate()
             {
                 println!("# {no}");


### PR DESCRIPTION
This closes #268. (We may (re)add a `nom` feature later should anyone be interested.)