### PR TITLE
refactor: Refactor `Decoder`.

### DIFF
--- a/assets/demos/tokio-support/src/client.rs
+++ b/assets/demos/tokio-support/src/client.rs
@@ -68,7 +68,7 @@ impl TokioDecoder for ImapClientCodec {
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         loop {
             if self.imap_state == State::Greeting {
-                match GreetingCodec::decode(src) {
+                match GreetingCodec::default().decode(src) {
                     Ok((remaining, grt)) => {
                         let grt = grt.into_static();
 
@@ -104,7 +104,8 @@ impl TokioDecoder for ImapClientCodec {
 
                                 // TODO: Choose the required parser.
                                 let parser = |input| {
-                                    ResponseCodec::decode(input)
+                                    ResponseCodec::default()
+                                        .decode(input)
                                         .map(|(rem, rsp)| (rem, Event::Response(rsp.into_static())))
                                 };
 

--- a/assets/demos/tokio-support/src/server.rs
+++ b/assets/demos/tokio-support/src/server.rs
@@ -83,7 +83,7 @@ impl TokioDecoder for ImapServerCodec {
                             let line = &src[..*to_consume_acc];
 
                             // TODO: Choose the required parser.
-                            match CommandCodec::decode(line) {
+                            match CommandCodec::default().decode(line) {
                                 // We got a complete message.
                                 Ok((rem, cmd)) => {
                                     assert!(rem.is_empty());

--- a/imap-codec/benches/parse_command.rs
+++ b/imap-codec/benches/parse_command.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use imap_codec::{decode::Decoder, imap_types::command::Command, CommandCodec};
 
 fn parse_command(input: &[u8]) -> Command {
-    let (_remaining, cmd) = CommandCodec::decode(input).unwrap();
+    let (_remaining, cmd) = CommandCodec::default().decode(input).unwrap();
 
     cmd
 }

--- a/imap-codec/benches/parse_response.rs
+++ b/imap-codec/benches/parse_response.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use imap_codec::{decode::Decoder, imap_types::response::Response, ResponseCodec};
 
 fn parse_response(input: &[u8]) -> Response {
-    let (_remaining, rsp) = ResponseCodec::decode(input).unwrap();
+    let (_remaining, rsp) = ResponseCodec::default().decode(input).unwrap();
 
     rsp
 }

--- a/imap-codec/examples/parse_command.rs
+++ b/imap-codec/examples/parse_command.rs
@@ -30,7 +30,7 @@ fn main() {
 
     loop {
         // Try to parse the first command in `buffer`.
-        match CommandCodec::decode(&buffer) {
+        match CommandCodec::default().decode(&buffer) {
             // Parser succeeded.
             Ok((remaining, command)) => {
                 // Do something with the command ...

--- a/imap-codec/examples/parse_greeting.rs
+++ b/imap-codec/examples/parse_greeting.rs
@@ -28,7 +28,7 @@ fn main() {
 
     loop {
         // Try to parse the first greeting in `buffer`.
-        match GreetingCodec::decode(&buffer) {
+        match GreetingCodec::default().decode(&buffer) {
             // Parser succeeded.
             Ok((remaining, greeting)) => {
                 // Do something with the greeting ...

--- a/imap-codec/examples/parse_response.rs
+++ b/imap-codec/examples/parse_response.rs
@@ -29,7 +29,7 @@ fn main() {
 
     loop {
         // Try to parse the first response in `buffer`.
-        match ResponseCodec::decode(&buffer) {
+        match ResponseCodec::default().decode(&buffer) {
             // Parser succeeded.
             Ok((remaining, response)) => {
                 // Do something with the response ...

--- a/imap-codec/fuzz/src/lib.rs
+++ b/imap-codec/fuzz/src/lib.rs
@@ -93,7 +93,7 @@ macro_rules! impl_to_bytes_and_back {
             #[cfg(feature = "debug")]
             println!("[!] Serialized: {}", escape_byte_string(&buffer));
 
-            let (rem, parsed) = <$codec>::decode(&buffer).unwrap();
+            let (rem, parsed) = <$codec>::default().decode(&buffer).unwrap();
             assert!(rem.is_empty());
 
             #[cfg(feature = "debug")]

--- a/imap-codec/fuzz/src/lib.rs
+++ b/imap-codec/fuzz/src/lib.rs
@@ -11,7 +11,7 @@ macro_rules! impl_decode_target {
             #[cfg(feature = "debug")]
             println!("[!] Input:      {}", escape_byte_string(input));
 
-            if let Ok((_rem, parsed1)) = $codec::decode(input) {
+            if let Ok((_rem, parsed1)) = $codec::default().decode(input) {
                 #[cfg(feature = "debug")]
                 {
                     let input = &input[..input.len() - _rem.len()];
@@ -23,7 +23,7 @@ macro_rules! impl_decode_target {
                 #[cfg(feature = "debug")]
                 println!("[!] Serialized: {}", escape_byte_string(&output));
 
-                let (rem, parsed2) = $codec::decode(&output).unwrap();
+                let (rem, parsed2) = $codec::default().decode(&output).unwrap();
                 #[cfg(feature = "debug")]
                 println!("[!] Parsed2: {parsed2:?}");
                 assert!(rem.is_empty());

--- a/imap-codec/src/codec.rs
+++ b/imap-codec/src/codec.rs
@@ -186,13 +186,13 @@ mod tests {
         ];
 
         for (test, expected) in tests {
-            let got = GreetingCodec::decode(test);
+            let got = GreetingCodec::default().decode(test);
             dbg!((std::str::from_utf8(test).unwrap(), &expected, &got));
             assert_eq!(expected, got);
 
             #[cfg(feature = "bounded-static")]
             {
-                let got = GreetingCodec::decode_static(test);
+                let got = GreetingCodec::default().decode_static(test);
                 assert_eq!(expected, got);
             }
         }
@@ -239,13 +239,13 @@ mod tests {
         ];
 
         for (test, expected) in tests {
-            let got = CommandCodec::decode(test);
+            let got = CommandCodec::default().decode(test);
             dbg!((std::str::from_utf8(test).unwrap(), &expected, &got));
             assert_eq!(expected, got);
 
             #[cfg(feature = "bounded-static")]
             {
-                let got = CommandCodec::decode_static(test);
+                let got = CommandCodec::default().decode_static(test);
                 assert_eq!(expected, got);
             }
         }
@@ -284,13 +284,13 @@ mod tests {
         ];
 
         for (test, expected) in tests {
-            let got = ResponseCodec::decode(test);
+            let got = ResponseCodec::default().decode(test);
             dbg!((std::str::from_utf8(test).unwrap(), &expected, &got));
             assert_eq!(expected, got);
 
             #[cfg(feature = "bounded-static")]
             {
-                let got = ResponseCodec::decode_static(test);
+                let got = ResponseCodec::default().decode_static(test);
                 assert_eq!(expected, got);
             }
         }

--- a/imap-codec/src/extensions/idle.rs
+++ b/imap-codec/src/extensions/idle.rs
@@ -107,7 +107,7 @@ mod tests {
         ];
 
         for (test, expected) in tests {
-            let got = IdleDoneCodec::decode(test);
+            let got = IdleDoneCodec::default().decode(test);
 
             dbg!((std::str::from_utf8(test).unwrap(), &expected, &got));
 

--- a/imap-codec/src/lib.rs
+++ b/imap-codec/src/lib.rs
@@ -30,8 +30,9 @@
 //! #     },
 //! #     GreetingCodec,
 //! #  };
-//! let (remaining, greeting) =
-//!     GreetingCodec::decode(b"* OK [ALERT] Hello, World!\r\n<remaining>").unwrap();
+//! let (remaining, greeting) = GreetingCodec::default()
+//!     .decode(b"* OK [ALERT] Hello, World!\r\n<remaining>")
+//!     .unwrap();
 //!
 //! assert_eq!(
 //!     greeting,

--- a/imap-codec/src/testing.rs
+++ b/imap-codec/src/testing.rs
@@ -56,7 +56,7 @@ macro_rules! impl_kat_inverse {
             {
                 println!("# {no}");
 
-                let (got_remainder, got_object) = $decoder::decode(test_input).unwrap();
+                let (got_remainder, got_object) = $decoder::default().decode(test_input).unwrap();
                 assert_eq!(*expected_object, got_object);
                 assert_eq!(*expected_remainder, got_remainder);
 
@@ -67,7 +67,8 @@ macro_rules! impl_kat_inverse {
 
                 // This second `decode` makes using generic bounds more complicated due to the
                 // different lifetime.
-                let (got_remainder, got_object_again) = $decoder::decode(&got_output).unwrap();
+                let (got_remainder, got_object_again) =
+                    $decoder::default().decode(&got_output).unwrap();
                 assert_eq!(got_object, got_object_again);
                 assert!(got_remainder.is_empty());
             }

--- a/imap-codec/tests/readme.rs
+++ b/imap-codec/tests/readme.rs
@@ -4,7 +4,7 @@ use imap_codec::{decode::Decoder, encode::Encoder, CommandCodec};
 fn test_from_readme() {
     let input = b"ABCD UID FETCH 1,2:* (BODY.PEEK[1.2.3.4.MIME]<42.1337>)\r\n";
 
-    let (_remainder, parsed) = CommandCodec::decode(input).unwrap();
+    let (_remainder, parsed) = CommandCodec::default().decode(input).unwrap();
     println!("# Parsed\n\n{:#?}\n\n", parsed);
 
     let buffer = CommandCodec::default().encode(&parsed).dump();

--- a/imap-codec/tests/trace.rs
+++ b/imap-codec/tests/trace.rs
@@ -69,7 +69,7 @@ fn test_lines_of_trace(trace: &[u8]) {
         match who {
             Who::Client => {
                 println!("C:          {}", String::from_utf8_lossy(&line).trim());
-                let (rem, parsed) = CommandCodec::decode(&line).unwrap();
+                let (rem, parsed) = CommandCodec::default().decode(&line).unwrap();
                 assert!(rem.is_empty());
                 println!("Parsed      {:?}", parsed);
                 let serialized = CommandCodec::default().encode(&parsed).dump();
@@ -77,14 +77,14 @@ fn test_lines_of_trace(trace: &[u8]) {
                     "Serialized: {}",
                     String::from_utf8_lossy(&serialized).trim()
                 );
-                let (rem, parsed2) = CommandCodec::decode(&serialized).unwrap();
+                let (rem, parsed2) = CommandCodec::default().decode(&serialized).unwrap();
                 assert!(rem.is_empty());
                 assert_eq!(parsed, parsed2);
                 println!()
             }
             Who::Server => {
                 println!("S:          {}", String::from_utf8_lossy(&line).trim());
-                let (rem, parsed) = ResponseCodec::decode(&line).unwrap();
+                let (rem, parsed) = ResponseCodec::default().decode(&line).unwrap();
                 println!("Parsed:     {:?}", parsed);
                 assert!(rem.is_empty());
                 let serialized = ResponseCodec::default().encode(&parsed).dump();
@@ -92,7 +92,7 @@ fn test_lines_of_trace(trace: &[u8]) {
                     "Serialized: {}",
                     String::from_utf8_lossy(&serialized).trim()
                 );
-                let (rem, parsed2) = ResponseCodec::decode(&serialized).unwrap();
+                let (rem, parsed2) = ResponseCodec::default().decode(&serialized).unwrap();
                 assert!(rem.is_empty());
                 assert_eq!(parsed, parsed2);
                 println!()
@@ -106,24 +106,24 @@ fn test_trace_known_positive(tests: Vec<(&[u8], Message)>) {
         println!("// {}", std::str::from_utf8(test).unwrap().trim());
         match expected {
             Message::Command(expected) => {
-                let (rem, got) = CommandCodec::decode(test).unwrap();
+                let (rem, got) = CommandCodec::default().decode(test).unwrap();
                 assert!(rem.is_empty());
                 assert_eq!(expected, got);
                 println!("{:?}", got);
                 let encoded = CommandCodec::default().encode(&got).dump();
                 println!("// {}", String::from_utf8(encoded.clone()).unwrap().trim());
-                let (rem2, got2) = CommandCodec::decode(&encoded).unwrap();
+                let (rem2, got2) = CommandCodec::default().decode(&encoded).unwrap();
                 assert!(rem2.is_empty());
                 assert_eq!(expected, got2);
             }
             Message::Response(expected) => {
-                let (rem, got) = ResponseCodec::decode(test).unwrap();
+                let (rem, got) = ResponseCodec::default().decode(test).unwrap();
                 assert!(rem.is_empty());
                 assert_eq!(expected, got);
                 println!("{:?}", got);
                 let encoded = ResponseCodec::default().encode(&got).dump();
                 println!("// {}", String::from_utf8(encoded.clone()).unwrap().trim());
-                let (rem2, got2) = ResponseCodec::decode(&encoded).unwrap();
+                let (rem2, got2) = ResponseCodec::default().decode(&encoded).unwrap();
                 assert!(rem2.is_empty());
                 assert_eq!(expected, got2);
             }
@@ -1270,7 +1270,7 @@ fn test_response_status_preauth() {
     let line = b"* PREAUTH IMAP4rev1 server logged in as Smith\r\n";
 
     println!("S:          {}", String::from_utf8_lossy(line).trim());
-    let (rem, parsed) = GreetingCodec::decode(line).unwrap();
+    let (rem, parsed) = GreetingCodec::default().decode(line).unwrap();
     println!("Parsed:     {:?}", parsed);
     assert!(rem.is_empty());
     let serialized = GreetingCodec::default().encode(&parsed).dump();
@@ -1278,7 +1278,7 @@ fn test_response_status_preauth() {
         "Serialized: {}",
         String::from_utf8_lossy(&serialized).trim()
     );
-    let (rem, parsed2) = GreetingCodec::decode(&serialized).unwrap();
+    let (rem, parsed2) = GreetingCodec::default().decode(&serialized).unwrap();
     assert!(rem.is_empty());
     assert_eq!(parsed, parsed2);
     println!()
@@ -1392,7 +1392,7 @@ S: A044 BAD No such command as "BLURDYBLOOP"
 fn test_trace_rfc2088() {
     let test = b"A001 LOGIN {11+}\r\nFRED FOOBAR {7+}\r\nfat man\r\n".as_ref();
 
-    let (rem, got) = CommandCodec::decode(test).unwrap();
+    let (rem, got) = CommandCodec::default().decode(test).unwrap();
     assert!(rem.is_empty());
     assert_eq!(got, {
         let username = Literal::try_from("FRED FOOBAR").unwrap().into_non_sync();


### PR DESCRIPTION
* Added `&self` to `Decoder`.
* Renamed `Item` to `Message`. (I think from all options naming it `Message` is the best.)