### PR TITLE
feat: Implement `ID` (RFC 2971)

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Check for SemVer violations | imap-types
         run: |
           cd imap-types
-          cargo semver-checks check-release
+          cargo semver-checks check-release --only-explicit-features
 
       - name: Check for SemVer violations | imap-codec
         run: |
           cd imap-codec
-          cargo semver-checks check-release
+          cargo semver-checks check-release --only-explicit-features

--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -24,6 +24,7 @@ starttls = ["imap-types/starttls"]
 ext_condstore_qresync = ["imap-types/ext_condstore_qresync"]
 ext_login_referrals = ["imap-types/ext_login_referrals"]
 ext_mailbox_referrals = ["imap-types/ext_mailbox_referrals"]
+ext_id = ["imap-types/ext_id"]
 # </Forward to imap-types>
 
 # IMAP quirks
@@ -41,6 +42,11 @@ quirk_rectify_numbers = []
 # Observed in ...
 # * Gmail `* OK [HIGHESTMODSEQ <n>]\r\n`
 quirk_missing_text = []
+# Encode `A ID ()` as `A ID NIL
+# Observed in ...
+# * GMX
+# * Microsoft Exchange
+quirk_id_empty_to_nil = []
 
 [dependencies]
 abnf-core = "0.6.0"

--- a/imap-codec/fuzz/Cargo.toml
+++ b/imap-codec/fuzz/Cargo.toml
@@ -18,6 +18,7 @@ starttls = ["imap-codec/starttls"]
 ext_condstore_qresync = ["imap-codec/ext_condstore_qresync"]
 ext_login_referrals = ["imap-codec/ext_login_referrals"]
 ext_mailbox_referrals = ["imap-codec/ext_mailbox_referrals"]
+ext_id = ["imap-codec/ext_id"]
 
 # IMAP quirks
 quirk_crlf_relaxed = ["imap-codec/quirk_crlf_relaxed"]
@@ -29,6 +30,7 @@ ext = [
     "ext_condstore_qresync",
     #"ext_login_referrals",
     #"ext_mailbox_referrals",
+    "ext_id",
 ]
 # Enable `Debug`-printing during parsing. This is useful to analyze crashes.
 debug = []

--- a/imap-codec/src/extensions.rs
+++ b/imap-codec/src/extensions.rs
@@ -1,5 +1,7 @@
 pub mod compress;
 pub mod enable;
+#[cfg(feature = "ext_id")]
+pub mod id;
 pub mod idle;
 pub mod literal;
 pub mod r#move;

--- a/imap-codec/src/extensions/id.rs
+++ b/imap-codec/src/extensions/id.rs
@@ -1,0 +1,148 @@
+//! IMAP4 ID extension
+
+// Additional changes:
+//
+// command_any ::= "CAPABILITY" / "LOGOUT" / "NOOP" / x_command / id
+// response_data ::= "*" SPACE (resp_cond_state / resp_cond_bye / mailbox_data / message_data / capability_data / id_response)
+
+use abnf_core::streaming::sp;
+use imap_types::core::{IString, NString};
+use nom::{
+    branch::alt,
+    bytes::streaming::{tag, tag_no_case},
+    combinator::{map, value},
+    multi::separated_list0,
+    sequence::{delimited, preceded, separated_pair},
+};
+
+use crate::{
+    core::{nil, nstring, string},
+    decode::IMAPResult,
+};
+
+/// ```abnf
+/// id = "ID" SPACE id_params_list
+/// ```
+///
+/// Note: Updated ABNF.
+pub(crate) fn id(input: &[u8]) -> IMAPResult<&[u8], Option<Vec<(IString, NString)>>> {
+    preceded(tag_no_case("ID "), id_params_list)(input)
+}
+
+/// ```abnf
+/// id_response = "ID" SPACE id_params_list
+/// ```
+///
+/// Note: Updated ABNF.
+#[inline]
+pub(crate) fn id_response(input: &[u8]) -> IMAPResult<&[u8], Option<Vec<(IString, NString)>>> {
+    id(input)
+}
+
+/// ```abnf
+/// id-params-list = "(" [string SP nstring *(SP string SP nstring)] ")" / nil
+/// ```
+///
+/// Note: Updated ABNF. (See https://github.com/modern-email/defects/issues/12)
+pub(crate) fn id_params_list(input: &[u8]) -> IMAPResult<&[u8], Option<Vec<(IString, NString)>>> {
+    alt((
+        map(
+            delimited(
+                tag("("),
+                separated_list0(sp, separated_pair(string, sp, nstring)),
+                tag(")"),
+            ),
+            Some,
+        ),
+        value(None, nil),
+    ))(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use imap_types::{
+        command::{Command, CommandBody},
+        core::{IString, NString},
+        response::{Data, Response},
+    };
+
+    use super::*;
+    use crate::testing::{kat_inverse_command, kat_inverse_response};
+
+    #[test]
+    fn test_parse_id() {
+        let got = id(b"id (\"name\" \"imap-codec\")\r\n").unwrap().1;
+        assert_eq!(
+            Some(vec![(
+                IString::try_from("name").unwrap(),
+                NString::try_from("imap-codec").unwrap()
+            )]),
+            got
+        );
+    }
+
+    #[test]
+    fn test_kat_inverse_command_id() {
+        kat_inverse_command(&[
+            (
+                b"A ID nil\r\n".as_ref(),
+                b"".as_ref(),
+                Command::new("A", CommandBody::Id { parameters: None }).unwrap(),
+            ),
+            (
+                b"A ID NIL\r\n".as_ref(),
+                b"".as_ref(),
+                Command::new("A", CommandBody::Id { parameters: None }).unwrap(),
+            ),
+            #[cfg(not(feature = "quirk_id_empty_to_nil"))]
+            (
+                b"A ID ()\r\n".as_ref(),
+                b"".as_ref(),
+                Command::new(
+                    "A",
+                    CommandBody::Id {
+                        parameters: Some(vec![]),
+                    },
+                )
+                .unwrap(),
+            ),
+            (
+                b"A ID (\"\" \"\")\r\n".as_ref(),
+                b"".as_ref(),
+                Command::new(
+                    "A",
+                    CommandBody::Id {
+                        parameters: Some(vec![(
+                            IString::try_from("").unwrap(),
+                            NString::try_from("").unwrap(),
+                        )]),
+                    },
+                )
+                .unwrap(),
+            ),
+            (
+                b"A ID (\"name\" \"imap-codec\")\r\n".as_ref(),
+                b"".as_ref(),
+                Command::new(
+                    "A",
+                    CommandBody::Id {
+                        parameters: Some(vec![(
+                            IString::try_from("name").unwrap(),
+                            NString::try_from("imap-codec").unwrap(),
+                        )]),
+                    },
+                )
+                .unwrap(),
+            ),
+        ]);
+    }
+
+    #[test]
+    fn test_kat_inverse_response_id() {
+        kat_inverse_response(&[(
+            b"* ID nil\r\n".as_ref(),
+            b"".as_ref(),
+            Response::Data(Data::Id { parameters: None }),
+        )]);
+    }
+}

--- a/imap-types/Cargo.toml
+++ b/imap-types/Cargo.toml
@@ -21,6 +21,7 @@ starttls = []
 ext_condstore_qresync = []
 ext_login_referrals = []
 ext_mailbox_referrals = []
+ext_id = []
 
 # Unlock `unvalidated` constructors.
 unvalidated = []

--- a/imap-types/src/command.rs
+++ b/imap-types/src/command.rs
@@ -11,6 +11,8 @@ use bounded_static::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "ext_id")]
+use crate::core::{IString, NString};
 use crate::{
     auth::AuthMechanism,
     command::error::{AppendError, CopyError, ListError, LoginError, RenameError},
@@ -1362,6 +1364,13 @@ pub enum CommandBody<'a> {
         /// Use UID variant.
         uid: bool,
     },
+
+    #[cfg(feature = "ext_id")]
+    /// ID command.
+    Id {
+        /// Parameters.
+        parameters: Option<Vec<(IString<'a>, NString<'a>)>>,
+    },
 }
 
 impl<'a> CommandBody<'a> {
@@ -1645,6 +1654,8 @@ impl<'a> CommandBody<'a> {
             Self::GetQuotaRoot { .. } => "GETQUOTAROOT",
             Self::SetQuota { .. } => "SETQUOTA",
             Self::Move { .. } => "MOVE",
+            #[cfg(feature = "ext_id")]
+            Self::Id { .. } => "ID",
         }
     }
 }

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -14,6 +14,8 @@ use bounded_static::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "ext_id")]
+use crate::core::{IString, NString};
 use crate::{
     auth::AuthMechanism,
     core::{impl_try_from, AString, Atom, Charset, NonEmptyVec, QuotedChar, Tag, Text},
@@ -549,6 +551,13 @@ pub enum Data<'a> {
         mailbox: Mailbox<'a>,
         /// List of quota roots.
         roots: Vec<AString<'a>>,
+    },
+
+    #[cfg(feature = "ext_id")]
+    /// ID Response
+    Id {
+        /// Parameters
+        parameters: Option<Vec<(IString<'a>, NString<'a>)>>,
     },
 }
 
@@ -1097,6 +1106,9 @@ pub enum Capability<'a> {
     LiteralMinus,
     /// See RFC 6851.
     Move,
+    #[cfg(feature = "ext_id")]
+    /// See RFC 2971.
+    Id,
     /// Other/Unknown
     Other(CapabilityOther<'a>),
 }
@@ -1124,6 +1136,8 @@ impl<'a> Display for Capability<'a> {
             Self::LiteralPlus => write!(f, "LITERAL+"),
             Self::LiteralMinus => write!(f, "LITERAL-"),
             Self::Move => write!(f, "MOVE"),
+            #[cfg(feature = "ext_id")]
+            Self::Id => write!(f, "ID"),
             Self::Other(other) => write!(f, "{}", other.0),
         }
     }
@@ -1179,6 +1193,8 @@ impl<'a> From<Atom<'a>> for Capability<'a> {
             "literal+" => Self::LiteralPlus,
             "literal-" => Self::LiteralMinus,
             "move" => Self::Move,
+            #[cfg(feature = "ext_id")]
+            "id" => Self::Id,
             _ => {
                 // TODO(efficiency)
                 if let Some((left, right)) = split_once_cow(cow.clone(), "=") {


### PR DESCRIPTION
Closes #375 

# TODO

* [x] `Capability::Id`
* [x] Allow sending an empty but present list, i.e., `A1 ID ()`? -> Follow RFC but provide `quirk_id_empty_to_nil`
* [x] More in #400