### PR TITLE
feat: Implement `Copy` for some types

### DIFF
--- a/imap-codec/src/codec/decode.rs
+++ b/imap-codec/src/codec/decode.rs
@@ -127,7 +127,7 @@ pub trait Decoder {
 
 /// Error during greeting decoding.
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GreetingDecodeError {
     /// More data is needed.
     Incomplete,
@@ -198,7 +198,7 @@ pub enum CommandDecodeError<'a> {
 
 /// Error during authenticate data line decoding.
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AuthenticateDataDecodeError {
     /// More data is needed.
     Incomplete,
@@ -233,7 +233,7 @@ pub enum ResponseDecodeError {
 
 /// Error during idle done decoding.
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum IdleDoneDecodeError {
     /// More data is needed.
     Incomplete,

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -86,7 +86,7 @@ impl<'a> Greeting<'a> {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// IMAP4rev1 defines three possible greetings at connection startup.
 pub enum GreetingKind {
     /// The connection is not yet authenticated.
@@ -628,7 +628,7 @@ pub struct StatusBody<'a> {
     pub text: Text<'a>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum StatusKind {
     Ok,
     No,


### PR DESCRIPTION
Closes #401 

Note: `Copy` is an API commitment. There are some `non_exhaustive` types that could already be `Copy` as well, but I'm not sure all variants will be in the future.