### PR TITLE
[DO NOT MERGE] Follow modifications done to imap-codec for Aerogramme 

### DIFF
--- a/imap-codec/src/codec.rs
+++ b/imap-codec/src/codec.rs
@@ -112,6 +112,7 @@ mod tests {
                     "a",
                     CommandBody::Select {
                         mailbox: Mailbox::Inbox,
+                        parameters: None,
                     },
                 )
                 .unwrap(),
@@ -123,6 +124,7 @@ mod tests {
                     "a",
                     CommandBody::Select {
                         mailbox: Mailbox::Inbox,
+                        parameters: None,
                     },
                 )
                 .unwrap(),

--- a/imap-codec/src/codec.rs
+++ b/imap-codec/src/codec.rs
@@ -138,12 +138,12 @@ mod tests {
             (
                 b"* SEARCH 1\r\n".as_ref(),
                 b"".as_ref(),
-                Response::Data(Data::Search(vec![NonZeroU32::new(1).unwrap()])),
+                Response::Data(Data::Search(vec![NonZeroU32::new(1).unwrap()], None)),
             ),
             (
                 b"* SEARCH 1\r\n???",
                 b"???",
-                Response::Data(Data::Search(vec![NonZeroU32::new(1).unwrap()])),
+                Response::Data(Data::Search(vec![NonZeroU32::new(1).unwrap()], None)),
             ),
             (
                 b"* 1 FETCH (RFC822 {5}\r\nhello)\r\n",

--- a/imap-codec/src/codec.rs
+++ b/imap-codec/src/codec.rs
@@ -112,7 +112,7 @@ mod tests {
                     "a",
                     CommandBody::Select {
                         mailbox: Mailbox::Inbox,
-                        parameters: None,
+                        modifiers: vec![],
                     },
                 )
                 .unwrap(),
@@ -124,7 +124,7 @@ mod tests {
                     "a",
                     CommandBody::Select {
                         mailbox: Mailbox::Inbox,
-                        parameters: None,
+                        modifiers: vec![],
                     },
                 )
                 .unwrap(),

--- a/imap-codec/src/codec/decode.rs
+++ b/imap-codec/src/codec/decode.rs
@@ -434,6 +434,7 @@ mod tests {
                         "a",
                         CommandBody::Select {
                             mailbox: Mailbox::Inbox,
+                            parameters: None,
                         },
                     )
                     .unwrap(),
@@ -447,6 +448,7 @@ mod tests {
                         "a",
                         CommandBody::Select {
                             mailbox: Mailbox::Inbox,
+                            parameters: None,
                         },
                     )
                     .unwrap(),

--- a/imap-codec/src/codec/decode.rs
+++ b/imap-codec/src/codec/decode.rs
@@ -646,14 +646,14 @@ mod tests {
                 b"* SEARCH 1\r\n".as_ref(),
                 Ok((
                     b"".as_ref(),
-                    Response::Data(Data::Search(vec![NonZeroU32::new(1).unwrap()])),
+                    Response::Data(Data::Search(vec![NonZeroU32::new(1).unwrap()], None)),
                 )),
             ),
             (
                 b"* SEARCH 1\r\n???".as_ref(),
                 Ok((
                     b"???".as_ref(),
-                    Response::Data(Data::Search(vec![NonZeroU32::new(1).unwrap()])),
+                    Response::Data(Data::Search(vec![NonZeroU32::new(1).unwrap()], None)),
                 )),
             ),
             (

--- a/imap-codec/src/codec/decode.rs
+++ b/imap-codec/src/codec/decode.rs
@@ -434,7 +434,7 @@ mod tests {
                         "a",
                         CommandBody::Select {
                             mailbox: Mailbox::Inbox,
-                            parameters: None,
+                            modifiers: vec![],
                         },
                     )
                     .unwrap(),
@@ -448,7 +448,7 @@ mod tests {
                         "a",
                         CommandBody::Select {
                             mailbox: Mailbox::Inbox,
-                            parameters: None,
+                            modifiers: vec![],
                         },
                     )
                     .unwrap(),

--- a/imap-codec/src/codec/encode.rs
+++ b/imap-codec/src/codec/encode.rs
@@ -439,7 +439,14 @@ impl<'a> EncodeIntoContext for CommandBody<'a> {
             }
             CommandBody::Check => ctx.write_all(b"CHECK"),
             CommandBody::Close => ctx.write_all(b"CLOSE"),
-            CommandBody::Expunge => ctx.write_all(b"EXPUNGE"),
+            CommandBody::Expunge { uid_sequence_set } => {
+                if let Some(seqset) = uid_sequence_set {
+                    ctx.write_all(b"UID EXPUNGE ")?;
+                    seqset.encode_ctx(ctx)
+                } else {
+                    ctx.write_all(b"EXPUNGE")
+                }
+            }
             CommandBody::Search {
                 charset,
                 criteria,

--- a/imap-codec/src/codec/encode.rs
+++ b/imap-codec/src/codec/encode.rs
@@ -737,7 +737,6 @@ impl EncodeIntoContext for StatusDataItemName {
             Self::Unseen => ctx.write_all(b"UNSEEN"),
             Self::Deleted => ctx.write_all(b"DELETED"),
             Self::DeletedStorage => ctx.write_all(b"DELETED-STORAGE"),
-            #[cfg(feature = "ext_condstore_qresync")]
             Self::HighestModSeq => ctx.write_all(b"HIGHESTMODSEQ"),
         }
     }
@@ -1385,6 +1384,10 @@ impl EncodeIntoContext for StatusDataItem {
             Self::DeletedStorage(count) => {
                 ctx.write_all(b"DELETED-STORAGE ")?;
                 count.encode_ctx(ctx)
+            }
+            Self::HighestModSeq(modseq) => {
+                ctx.write_all(b"HIGHESTMODSEQ ")?;
+                modseq.encode_ctx(ctx)
             }
         }
     }

--- a/imap-codec/src/codec/encode.rs
+++ b/imap-codec/src/codec/encode.rs
@@ -1280,12 +1280,18 @@ impl<'a> EncodeIntoContext for Data<'a> {
                 join_serializable(items, b" ", ctx)?;
                 ctx.write_all(b")")?;
             }
-            Data::Search(seqs) => {
+            Data::Search(seqs, maybe_modseq) => {
                 if seqs.is_empty() {
                     ctx.write_all(b"* SEARCH")?;
                 } else {
                     ctx.write_all(b"* SEARCH ")?;
                     join_serializable(seqs, b" ", ctx)?;
+                    if let Some(modseq) = maybe_modseq {
+                        ctx.write_all(b" (MODSEQ ")?;
+                        modseq.encode_ctx(ctx)?;
+                        ctx.write_all(b")")?;
+                    }
+                    
                 }
             }
             Data::Flags(flags) => {

--- a/imap-codec/src/core.rs
+++ b/imap-codec/src/core.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, num::NonZeroU32, str::from_utf8};
+use std::{borrow::Cow, num::{NonZeroU32, NonZeroU64}, str::from_utf8};
 
 #[cfg(not(feature = "quirk_crlf_relaxed"))]
 use abnf_core::streaming::crlf;
@@ -63,6 +63,10 @@ pub(crate) fn number64(input: &[u8]) -> IMAPResult<&[u8], u64> {
 /// Non-zero unsigned 32-bit integer (0 < n < 4,294,967,296)
 pub(crate) fn nz_number(input: &[u8]) -> IMAPResult<&[u8], NonZeroU32> {
     map_res(number, NonZeroU32::try_from)(input)
+}
+
+pub(crate) fn nz_number64(input: &[u8]) -> IMAPResult<&[u8], NonZeroU64> {
+    map_res(number64, NonZeroU64::try_from)(input)
 }
 
 // ----- string -----

--- a/imap-codec/src/fetch.rs
+++ b/imap-codec/src/fetch.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32};
 
 use abnf_core::streaming::sp;
 use imap_types::{
@@ -15,7 +15,7 @@ use nom::{
 
 use crate::{
     body::body,
-    core::{astring, nstring, number, nz_number},
+    core::{astring, nstring, number, nz_number64, nz_number},
     datetime::date_time,
     decode::IMAPResult,
     envelope::envelope,
@@ -83,6 +83,7 @@ pub(crate) fn fetch_att(input: &[u8]) -> IMAPResult<&[u8], MessageDataItemName> 
         value(MessageDataItemName::Rfc822Size, tag_no_case(b"RFC822.SIZE")),
         value(MessageDataItemName::Rfc822Text, tag_no_case(b"RFC822.TEXT")),
         value(MessageDataItemName::Rfc822, tag_no_case(b"RFC822")),
+        value(MessageDataItemName::ModSeq, tag_no_case(b"MODSEQ")),
     ))(input)
 }
 
@@ -174,6 +175,9 @@ pub(crate) fn msg_att_static(input: &[u8]) -> IMAPResult<&[u8], MessageDataItem>
         ),
         map(tuple((tag_no_case(b"UID"), sp, uniqueid)), |(_, _, uid)| {
             MessageDataItem::Uid(uid)
+        }),
+        map(tuple((tag_no_case(b"MODSEQ "), delimited(tag("("), nz_number64, tag(")")))), |(_, modseq)| {
+            MessageDataItem::ModSeq(modseq)
         }),
     ))(input)
 }

--- a/imap-codec/src/response.rs
+++ b/imap-codec/src/response.rs
@@ -452,7 +452,7 @@ mod tests {
                     2.try_into().unwrap(),
                     3.try_into().unwrap(),
                     42.try_into().unwrap(),
-                ])),
+                ], None)),
             ),
             (b"* 42 EXISTS\r\n", b"", Response::Data(Data::Exists(42))),
             (

--- a/imap-codec/tests/trace.rs
+++ b/imap-codec/tests/trace.rs
@@ -947,7 +947,7 @@ fn test_transcript_from_rfc() {
                 Message::Command(
                     Command::new(
                         "a003",
-                        CommandBody::fetch("12", Macro::Full, false).unwrap(),
+                        CommandBody::fetch("12", vec![], Macro::Full, false).unwrap(),
                     )
                     .unwrap(),
                 ),
@@ -1078,6 +1078,7 @@ fn test_transcript_from_rfc() {
                         "a004",
                         CommandBody::fetch(
                             "12",
+                            vec![],
                             vec![MessageDataItemName::BodyExt {
                                 section: Some(Section::Header(None)),
                                 peek: false,

--- a/imap-codec/tests/trace.rs
+++ b/imap-codec/tests/trace.rs
@@ -1150,6 +1150,7 @@ Content-Type: TEXT/PLAIN; CHARSET=US-ASCII\r
                             StoreType::Add,
                             StoreResponse::Answer,
                             vec![Flag::Deleted],
+                            vec![],
                             false,
                         )
                         .unwrap(),

--- a/imap-types/src/command.rs
+++ b/imap-types/src/command.rs
@@ -960,7 +960,9 @@ pub enum CommandBody<'a> {
     ///   Note: In this example, messages 3, 4, 7, and 11 had the
     ///   \Deleted flag set.  See the description of the EXPUNGE
     ///   response for further explanation.
-    Expunge,
+    Expunge { 
+        uid_sequence_set: Option<SequenceSet>,
+    },
 
     /// ### 6.4.4.  SEARCH Command
     ///
@@ -1680,7 +1682,7 @@ impl<'a> CommandBody<'a> {
             Self::Append { .. } => "APPEND",
             Self::Check => "CHECK",
             Self::Close => "CLOSE",
-            Self::Expunge => "EXPUNGE",
+            Self::Expunge { .. } => "EXPUNGE",
             Self::Search { .. } => "SEARCH",
             Self::Fetch { .. } => "FETCH",
             Self::Store { .. } => "STORE",
@@ -1844,7 +1846,7 @@ mod tests {
             .unwrap(),
             CommandBody::Check,
             CommandBody::Close,
-            CommandBody::Expunge,
+            CommandBody::Expunge { uid_sequence_set: None },
             CommandBody::search(
                 None,
                 SearchKey::And(
@@ -2033,7 +2035,9 @@ mod tests {
             ),
             (CommandBody::Check, "CHECK"),
             (CommandBody::Close, "CLOSE"),
-            (CommandBody::Expunge, "EXPUNGE"),
+            (CommandBody::Expunge {
+                uid_sequence_set: None,
+            }, "EXPUNGE"),
             (
                 CommandBody::Search {
                     charset: None,

--- a/imap-types/src/command.rs
+++ b/imap-types/src/command.rs
@@ -1890,6 +1890,7 @@ mod tests {
             ),
             CommandBody::fetch(
                 "1",
+                vec![],
                 vec![MessageDataItemName::BodyExt {
                     partial: None,
                     section: Some(Section::Part(Part(
@@ -1902,7 +1903,7 @@ mod tests {
                 false,
             )
             .unwrap(),
-            CommandBody::fetch("1:*,2,3", Macro::Full, true).unwrap(),
+            CommandBody::fetch("1:*,2,3", vec![], Macro::Full, true).unwrap(),
             CommandBody::store(
                 "1,2:*",
                 StoreType::Remove,
@@ -1957,7 +1958,7 @@ mod tests {
             (
                 CommandBody::Select {
                     mailbox: Mailbox::Inbox,
-                    parameters: None,
+                    modifiers: vec![],
                 },
                 "SELECT",
             ),
@@ -1965,7 +1966,7 @@ mod tests {
             (
                 CommandBody::Examine {
                     mailbox: Mailbox::Inbox,
-                    parameters: None,
+                    modifiers: vec![],
                 },
                 "EXAMINE",
             ),
@@ -2045,6 +2046,7 @@ mod tests {
                 CommandBody::Fetch {
                     sequence_set: SequenceSet::try_from(1u32).unwrap(),
                     macro_or_item_names: MacroOrMessageDataItemNames::Macro(Macro::Full),
+                    modifiers: vec![],
                     uid: true,
                 },
                 "FETCH",

--- a/imap-types/src/fetch.rs
+++ b/imap-types/src/fetch.rs
@@ -2,7 +2,7 @@
 
 use std::{
     fmt::{Display, Formatter},
-    num::NonZeroU32,
+    num::{NonZeroU32, NonZeroU64},
 };
 
 #[cfg(feature = "arbitrary")]
@@ -229,6 +229,9 @@ pub enum MessageDataItemName<'a> {
     /// UID
     /// ```
     Uid,
+
+    /// The ModSeq of CONDSTORE
+    ModSeq,
 }
 
 /// Message data item.
@@ -356,6 +359,9 @@ pub enum MessageDataItem<'a> {
     /// UID
     /// ```
     Uid(NonZeroU32),
+
+    /// The ModSeq value described in CONDSTORE
+    ModSeq(NonZeroU64),
 }
 
 /// A part specifier is either a part number or one of the following:

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -3,7 +3,7 @@
 use std::{
     borrow::Cow,
     fmt::{Debug, Display, Formatter},
-    num::{NonZeroU32, TryFromIntError},
+    num::{NonZeroU32, NonZeroU64, TryFromIntError},
 };
 
 #[cfg(feature = "arbitrary")]
@@ -426,7 +426,10 @@ pub enum Data<'a> {
     /// search criteria.  For SEARCH, these are message sequence numbers;
     /// for UID SEARCH, these are unique identifiers.  Each number is
     /// delimited by a space.
-    Search(Vec<NonZeroU32>),
+    ///
+    /// Optionally, a modseq value can be set to inform the client the highest
+    /// modset in the set of returned messages.
+    Search(Vec<NonZeroU32>, Option<NonZeroU64>),
 
     /// ### 7.2.6.  FLAGS Response
     ///

--- a/imap-types/src/status.rs
+++ b/imap-types/src/status.rs
@@ -35,8 +35,6 @@ pub enum StatusDataItemName {
     /// The amount of storage space that can be reclaimed by performing EXPUNGE on the mailbox.
     DeletedStorage,
 
-    #[cfg(feature = "ext_condstore_qresync")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ext_condstore_qresync")))]
     HighestModSeq,
 }
 
@@ -69,4 +67,7 @@ pub enum StatusDataItem {
 
     /// The amount of storage space that can be reclaimed by performing EXPUNGE on the mailbox.
     DeletedStorage(u64),
+
+    /// The highest mod sequence in the mailbox
+    HighestModSeq(u64),
 }


### PR DESCRIPTION
I am currently working on implementing CONDSTORE in Aerogramme. You can track my work [on the dedicated merge request thread](https://git.deuxfleurs.fr/Deuxfleurs/aerogramme/pulls/71). I am opening a PR so you can see which features I needed to add so the feature works. The code is ugly and is not meant to be merged.

Relevant RFC: [4466](https://datatracker.ietf.org/doc/html/rfc4466) + [RFC7162](https://datatracker.ietf.org/doc/html/rfc7162)