### PR TITLE
CONDSTORE

### DIFF
--- a/imap-codec/src/core.rs
+++ b/imap-codec/src/core.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "ext_condstore_qresync")]
+use std::num::NonZeroU64;
 use std::{borrow::Cow, num::NonZeroU32, str::from_utf8};
 
 #[cfg(not(feature = "quirk_crlf_relaxed"))]
@@ -63,6 +65,15 @@ pub(crate) fn number64(input: &[u8]) -> IMAPResult<&[u8], u64> {
 /// Non-zero unsigned 32-bit integer (0 < n < 4,294,967,296)
 pub(crate) fn nz_number(input: &[u8]) -> IMAPResult<&[u8], NonZeroU32> {
     map_res(number, NonZeroU32::try_from)(input)
+}
+
+/// mod-sequence-value  = 1*DIGIT
+/// ;; Positive unsigned 64-bit integer
+/// ;; (mod-sequence)
+/// ;; (1 <= n < 18,446,744,073,709,551,615)
+#[cfg(feature = "ext_condstore_qresync")]
+pub(crate) fn mod_sequence_value(input: &[u8]) -> IMAPResult<&[u8], NonZeroU64> {
+    map_res(number64, NonZeroU64::try_from)(input)
 }
 
 // ----- string -----

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -1,5 +1,7 @@
 //! # 7. Server Responses
 
+#[cfg(feature = "ext_condstore_qresync")]
+use std::num::NonZeroU64;
 use std::{
     borrow::Cow,
     fmt::{Debug, Display, Formatter},
@@ -831,6 +833,34 @@ pub enum Code<'a> {
 
     /// Server got a non-synchronizing literal larger than 4096 bytes.
     TooBig,
+
+    /// IMAP4 Extension for Conditional STORE Operation (RFC 4551)
+    /// A server supporting the persistent storage of mod-sequences for the mailbox
+    /// MUST send the OK untagged response including HIGHESTMODSEQ response
+    /// code with every successful SELECT or EXAMINE command
+    #[cfg(feature = "ext_condstore_qresync")]
+    #[cfg_attr(docsrs, doc(cfg("ext_condstore_qresync")))]
+    HighestModSeq(NonZeroU64),
+
+    /// IMAP4 Extension for Conditional STORE Operation (RFC 4551)
+    /// When the server finished performing the operation on all the
+    /// messages in the message set, it checks for a non-empty list of
+    /// messages that failed the UNCHANGESINCE test.  If this list is
+    /// non-empty, the server MUST return in the tagged response a
+    /// MODIFIED response code.  The MODIFIED response code includes the
+    /// message set (for STORE) or set of UIDs (for UID STORE) of all
+    /// messages that failed the UNCHANGESINCE test.
+    #[cfg(feature = "ext_condstore_qresync")]
+    #[cfg_attr(docsrs, doc(cfg("ext_condstore_qresync")))]
+    Modified(Vec1<NonZeroU32>),
+
+    /// IMAP4 Extension for Conditional STORE Operation (RFC 4551)
+    /// A server that doesn't support the persistent storage of mod-sequences
+    /// for the mailbox MUST send the OK untagged response including NOMODSEQ
+    /// response code with every successful SELECT or EXAMINE command.
+    #[cfg(feature = "ext_condstore_qresync")]
+    #[cfg_attr(docsrs, doc(cfg("ext_condstore_qresync")))]
+    NoModSeq,
 
     /// Additional response codes defined by particular client or server
     /// implementations SHOULD be prefixed with an "X" until they are


### PR DESCRIPTION
## Progress 

- [X] CONDSTORE activation
   - [X] **ENABLE COMMAND:** CONDSTORE (already added by you some times ago)
- [ ] Response
   - [X] **SELECT/EXAMINE COMMAND:** HIGHESTMODSEQ Status Code *(RFC g. add.)*
   - [X] **SELECT/EXAMINE COMMAND:** NOMODSEQ Status Code *(RFC g. add.)*
   - [ ] **STATUS COMMAND** HIGHESTMODSEQ Response parameter to the STATUS Response *(RFC h. add.)* 
   - [ ] **FETCH COMMAND** MODSEQ data item *(RFC c. add)*
   - [X] **STORE COMMAND** MODIFIED STATUS RESPONSE CODE *(RFC b. add.)*
   - [ ] **SEARCH COMMAND** Extend search response syntax *(RFC f. add.)*
-  [ ] Modifiers
   - [ ] **SELECT/EXAMINE**: CONDSTORE MODIFIER *(RFC h. add.)*
   - [ ] **FETCH COMMAND**: CHANGEDSINCE modifier *(RFC d. add.)*
   - [ ] **STORE COMMAND**: UNCHANGEDSINCE modifier *(RFC a. add.)*
- [x] Query
   - [x] **FETCH COMMAND**: MODSEQ data item name *(RFC c. add.)*
   - [x] **SEARCH COMMAND**: MODSEQ *(RFC e. add.)*

## About this first commit

Hey Damian, I am trying to implement in a clean way condstore for imap-codec. I wanted to start with a scope as small as possible, that's why I have a commit adding support only for the status codes used by condstore. I propose you review this commit in depth, pinpoint all the problems with your conventions/standard, so I can backport the rest in a proper way?

## Some questions

As for now, I am validating my code with:

```
cargo build --features ext_condstore_qresync
cargo test --features ext_condstore_qresync
cargo clippy
cargo fmt
```

Is it ok? Is it normal that I have warnings when running `cargo fmt`? Do you know why the `imap-types/src/core.rs` file has been impacted by my `cargo fmt` despite the fact that I have not edited it?

Also, another question: I created a `mod_sequence_value` parser that use your `number64` parser. I did not name it `nz_number64` despite the same logic for NonZeroU32 being name `nz_number` as it seems you want to follow the ABNF grammar, and in the grammar, it's called `mod-sequence-value`. Am I correct?

Also, you said at FOSDEM '24 that often examples given in the RFC are wrong. It appears that `HIGHESTMODSEQ` is given without a text following the code. Reading your code let me guess that's wrong. For example:

```
      S: * 1 RECENT
      S: * OK [UNSEEN 12] Message 12 is first unseen
      S: * OK [UIDVALIDITY 3857529045] UIDs valid
      S: * OK [UIDNEXT 4392] Predicted next UID
      S: * FLAGS (\Answered \Flagged \Deleted \Seen \Draft)
      S: * OK [PERMANENTFLAGS (\Deleted \Seen \*)] Limited
      S: * OK [HIGHESTMODSEQ 715194045007]
      S: A142 OK [READ-WRITE] SELECT completed
```

Dovecot correctly adds the text `Highest` after the code:

```
      S: * OK [HIGHESTMODSEQ 715194045007] Highest
```

I don't know if it qualifies for your [IMAP defects](https://github.com/modern-email/defects) repository.
Also feel free to edit this pull request directly if needed.