### PR TITLE
feat: Implement `Clone` and `PartialEq` for codec types

### DIFF
--- a/imap-codec/src/codec.rs
+++ b/imap-codec/src/codec.rs
@@ -2,7 +2,7 @@ pub mod decode;
 pub mod encode;
 
 /// Codec for greetings.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 // We use `#[non_exhaustive]` to prevent users from using struct literal syntax.
 //
 // This allows to add configuration options later. For example, the
@@ -11,22 +11,22 @@ pub mod encode;
 pub struct GreetingCodec;
 
 /// Codec for commands.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct CommandCodec;
 
 /// Codec for authenticate data lines.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct AuthenticateDataCodec;
 
 /// Codec for responses.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct ResponseCodec;
 
 /// Codec for idle dones.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct IdleDoneCodec;
 


### PR DESCRIPTION
If I understand correctly the codec structs (e.g. `CommandCodec`) might contain options in the future that effect how messages are encoded/decoded. It's useful to implement `Clone` and `PartialEq` for such option structs. This PR does this.

Resolves #438