### PR TITLE
quirk: deal with Exchange's excessive space

### DIFF
--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [features]
-default = ["quirk_rectify_numbers", "quirk_missing_text"]
+default = ["quirk_rectify_numbers", "quirk_missing_text", "quirk_trailing_space"]
 
 # <Forward to imap-types>
 arbitrary = ["imap-types/arbitrary"]
@@ -50,6 +50,10 @@ quirk_missing_text = []
 # * GMX
 # * Microsoft Exchange
 quirk_id_empty_to_nil = []
+# Accept a trailing space in `STATUS` data response.
+# Observed in ...
+# * Microsoft Exchange `* STATUS INBOX (MESSAGES 100 UNSEEN 0) \n\n`
+quirk_trailing_space = []
 
 [dependencies]
 abnf-core = "0.6.0"

--- a/imap-codec/src/mailbox.rs
+++ b/imap-codec/src/mailbox.rs
@@ -106,8 +106,12 @@ pub(crate) fn mailbox_data(input: &[u8]) -> IMAPResult<&[u8], Data> {
                 mailbox,
                 sp,
                 delimited(tag(b"("), opt(status_att_list), tag(b")")),
+                #[cfg(feature = "quirk_trailing_space")]
+                opt(sp),
+                #[cfg(not(feature = "quirk_trailing_space"))]
+                nom::combinator::success(()),
             )),
-            |(_, _, mailbox, _, items)| Data::Status {
+            |(_, _, mailbox, _, items, _)| Data::Status {
                 mailbox,
                 items: items.unwrap_or_default().into(),
             },

--- a/imap-codec/src/response.rs
+++ b/imap-codec/src/response.rs
@@ -721,4 +721,20 @@ mod tests {
             assert!(resp_text(b"[IMAP4rev1]  \r\n").is_ok());
         }
     }
+
+    #[test]
+    fn test_parse_resp_space_quirk() {
+        assert!(response_data(b"* STATUS INBOX (MESSAGES 100 UNSEEN 0)\r\n").is_ok());
+        assert!(response_data(b"* STATUS INBOX (MESSAGES 100 UNSEEN 0)  \r\n").is_err());
+
+        #[cfg(not(feature = "quirk_trailing_space"))]
+        {
+            assert!(response_data(b"* STATUS INBOX (MESSAGES 100 UNSEEN 0) \r\n").is_err());
+        }
+
+        #[cfg(feature = "quirk_trailing_space")]
+        {
+            assert!(response_data(b"* STATUS INBOX (MESSAGES 100 UNSEEN 0) \r\n").is_ok());
+        }
+    }
 }


### PR DESCRIPTION
Microsoft Exchange responds STATUS with a trailing space, which is not RFC compliant.

This is similarly worked around in Ruby's imap library: https://bugs.ruby-lang.org/issues/13649