### PR TITLE
Structure Aware Tag Fuzz Target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
 name = "imap-codec-fuzz"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
  "imap-codec",
  "imap-types",
  "libfuzzer-sys",

--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -18,6 +18,9 @@ default = ["quirk_rectify_numbers", "quirk_missing_text", "quirk_trailing_space"
 # <Forward to imap-types>
 bounded-static = ["dep:bounded-static", "imap-types/bounded-static"]
 
+# Expose internal parsers for fuzzing
+fuzz = []
+
 # IMAP
 starttls = ["imap-types/starttls"]
 

--- a/imap-codec/fuzz/Cargo.toml
+++ b/imap-codec/fuzz/Cargo.toml
@@ -50,9 +50,10 @@ debug = []
 split = []
 
 [dependencies]
-libfuzzer-sys = "0.4"
+arbitrary = "1.3.2"
+imap-codec = { path = "..", features = ["fuzz"] }
 imap-types = { path = "../../imap-types", features = ["arbitrary"] }
-imap-codec = { path = ".." }
+libfuzzer-sys = "0.4"
 
 [[bin]]
 name = "greeting"
@@ -99,5 +100,11 @@ doc = false
 [[bin]]
 name = "authenticate_data_to_bytes_and_back"
 path = "fuzz_targets/authenticate_data_to_bytes_and_back.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "tags_structured"
+path = "fuzz_targets/tags_structured.rs"
 test = false
 doc = false

--- a/imap-codec/fuzz/fuzz_targets/tags_structured.rs
+++ b/imap-codec/fuzz/fuzz_targets/tags_structured.rs
@@ -1,0 +1,51 @@
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use imap_codec::fuzz::fuzz_tag_imap;
+use libfuzzer_sys::fuzz_target;
+
+/// Define a struct that represents fuzz target inputs.
+/// Includes both potentially valid and invalid tag patterns.
+#[derive(Debug)]
+struct TagInput {
+    /// String representing a valid or invalid IMAP tag
+    tag: String,
+    /// Additional field to simulate complex scenarios or invalid patterns
+    noise: Option<String>,
+}
+
+impl<'a> Arbitrary<'a> for TagInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let tag = u.arbitrary::<String>()?;
+        let noise = u.arbitrary::<Option<String>>()?;
+        Ok(Self { tag, noise })
+    }
+}
+
+fuzz_target!(|data: TagInput| {
+    // Combine tag and noise to generate the input
+    let mut input = data.tag;
+    if let Some(noise) = data.noise {
+        input.push_str(&noise);
+    }
+
+    // Convert the input string to bytes
+    let input_bytes = input.as_bytes();
+
+    // Attempt to parse the input as an IMAP tag
+    match fuzz_tag_imap(input_bytes) {
+        Ok((_, parsed_tag)) => {
+            // If parsing succeeds, validate the output
+            // Ensure the parsed tag is a subset of the original input
+            assert!(input.starts_with(parsed_tag.as_ref()));
+            // Optionally, check if the remaining bytes match the expected pattern for noise
+            // add more specific validations based on fuzzing requirements
+        }
+        Err(_) => {
+            // If parsing fails, check specific conditions
+            // Ensure that failure is due to the expected reasons
+            // Check for specific patterns that are known to be invalid
+        }
+    }
+    // Additional checks for performance metrics or memory safety checks
+});

--- a/imap-codec/src/lib.rs
+++ b/imap-codec/src/lib.rs
@@ -130,6 +130,11 @@ mod status;
 #[cfg(test)]
 mod testing;
 
+#[cfg(feature = "fuzz")]
+pub mod fuzz {
+    pub use crate::core::fuzz_tag_imap;
+}
+
 pub use codec::*;
 // Re-export.
 pub use imap_types;


### PR DESCRIPTION
Adds Basic Structure Aware Fuzzing for tag_imap:

- TagInput: A struct representing the input for the fuzz target.
- Arbitrary Implementation: This allows TagInput to be generated with random values.
- Conversion to Bytes: Converts the input string to bytes.
- Parsing: Attempts to parse the input bytes as an IMAP tag using tag_imap.
- Currently does not specify additional checks in the even of a parsing failure.

