### PR TITLE
fix: Handle different line endings and EOF in examples

### DIFF
--- a/imap-codec/examples/common/common.rs
+++ b/imap-codec/examples/common/common.rs
@@ -24,7 +24,8 @@ pub fn read_more(buffer: &mut Vec<u8>, role: Role) {
 
     let line = read_line(prompt, role);
 
-    if line.trim() == "exit" {
+    // If `read_line` produces an empty string, standard input has been closed.
+    if line.is_empty() || line.trim() == "exit" {
         println!("Exiting.");
         std::process::exit(0);
     }
@@ -44,6 +45,11 @@ fn read_line(prompt: &str, role: Role) -> String {
     std::io::stdin().read_line(&mut line).unwrap();
 
     print!("{RESET}");
+
+    // If `Stdin::read_line` produces an empty string, standard input has been closed.
+    if line.is_empty() {
+        return line;
+    }
 
     // Ensure `CRLF` line ending of resulting string.
     // Line ending of `line` can be one of:

--- a/imap-codec/examples/common/common.rs
+++ b/imap-codec/examples/common/common.rs
@@ -45,5 +45,16 @@ fn read_line(prompt: &str, role: Role) -> String {
 
     print!("{RESET}");
 
-    line.replace('\n', "\r\n")
+    // Ensure `CRLF` line ending of resulting string.
+    // Line ending of `line` can be one of:
+    // - `CRLF` on Windows
+    // - `LF` on Unix-like
+    // - none when EOF of standard input is reached
+    if line.ends_with("\r\n") {
+        return line;
+    }
+    if line.ends_with('\n') {
+        line.pop();
+    }
+    line + "\r\n"
 }


### PR DESCRIPTION
The `parse_*` examples for imap-codec were not running on Windows due to an incorrect conversion of an already existing `CRLF` line ending to an erroneous `CRCRLF` line ending.
This fixes the issue by ensuring a `CRLF` line ending in all possible cases.

Also, EOF of stdin is now handled and no longer results in an endless loop (e.g. `echo -n "* OK Hello" | cargo run -p imap-codec --example parse_greeting`).