### PR TITLE
build: Improve coverage reporting

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,12 +6,14 @@ on:
       - "**.rs"
       - "**.toml"
       - ".github/workflows/**"
+      - "justfile"
   pull_request:
     branches: [ main ]
     paths:
       - "**.rs"
       - "**.toml"
       - ".github/workflows/**"
+      - "justfile"
   schedule:
     # 21:43 on Wednesday and Sunday. (Thanks, crontab.guru)
     - cron: '43 21 * * 3,0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,14 @@ on:
       - "**.rs"
       - "**.toml"
       - ".github/workflows/**"
+      - "justfile"
   pull_request:
     branches: [ main ]
     paths:
       - "**.rs"
       - "**.toml"
       - ".github/workflows/**"
+      - "justfile"
   workflow_dispatch:
 
 concurrency:

--- a/justfile
+++ b/justfile
@@ -140,18 +140,24 @@ bench_against_main:
 # Measure test coverage
 coverage: install_rust_llvm_tools_preview install_cargo_grcov
     mkdir -p target/coverage
-    RUSTFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="coverage-%m-%p.profraw" cargo test -p imap-codec -p imap-types --all-features
-    grcov . \
+    # Remove old profiling information and coverage reports
+    rm -rf target/coverage/*
+    # Run instrumented tests to generate coverage information
+    RUSTFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="$PWD/target/coverage/coverage-%m-%p.profraw" cargo test -p imap-codec -p imap-types --all-features
+    # Generate coverage reports
+    # - LCOV info report for coveralls.io
+    # - HTML report for local use
+    grcov target/coverage \
         --source-dir . \
         --binary-path target/debug \
         --branch \
         --keep-only '{imap-codec/src/**,imap-types/src/**}' \
-        --output-types "lcov" \
-        --llvm > target/coverage/coverage.lcov
-    # TODO: Create files in `target/coverage` only.
-    rm *.profraw
-    rm imap-types/*.profraw
-    rm imap-codec/*.profraw
+        --llvm \
+        --output-types "html,lcov" \
+        --output-path target/coverage/
+    mv target/coverage/lcov target/coverage/coverage.lcov
+    # Remove profiling information to prevent wasting disk space
+    rm target/coverage/*.profraw
 
 # Fuzz all targets
 [linux]


### PR DESCRIPTION
- remove coverage artifacts before running the tests as well (otherwise, a failing test run may leave coverage artifacts in place)
- keep all coverage related files in `target/coverage`
- add creation of HTML report for local development use