### PR TITLE
fix(build): Use clean build for coverage test run

### DIFF
--- a/justfile
+++ b/justfile
@@ -139,9 +139,9 @@ bench_against_main:
 
 # Measure test coverage
 coverage: install_rust_llvm_tools_preview install_cargo_grcov
-    mkdir -p target/coverage
-    # Remove old profiling information and coverage reports
-    rm -rf target/coverage/*
+    # Old build artifacts seem to be able to mess up coverage data (see #508),
+    # removing everything in `target` seems to be the easiest fix for this.
+    rm -rf target/*
     # Run instrumented tests to generate coverage information
     RUSTFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="$PWD/target/coverage/coverage-%m-%p.profraw" cargo test -p imap-codec -p imap-types --all-features
     # Generate coverage reports


### PR DESCRIPTION
Previously, coverage data could be messed up by build artifacts restored from the GitHub cache. While it is not yet cleared up how this actually happens, removing all build data before executing the coverage test run seems to resolve this issue.

This fixes #508.