### PR TITLE
fix(build): Fix arguments to minimal version check

### DIFF
--- a/justfile
+++ b/justfile
@@ -175,7 +175,7 @@ fuzz runs="25000": install_cargo_fuzz
 minimal_versions: install_rust_1_65 install_rust_nightly
     cargo +nightly update -Z minimal-versions
     cargo +1.65 check \
-      --workspace --exclude tokio-client --exclude tokio-server --exclude imap-codec-bench\
+      --workspace --exclude tokio-client --exclude tokio-server --exclude imap-codec-bench \
       --all-targets --all-features 
     cargo +1.65 test \
       --workspace --exclude tokio-client --exclude tokio-server --exclude imap-codec-bench --exclude imap-codec-fuzz --exclude imap-types-fuzz \


### PR DESCRIPTION
Due to the missing space at the line continuation, the arguments are directly concatenated, resulting in `imap-codec-bench--all-targets` instead of separate arguments.
For the exclude parameter, this only results in a "package ... not found" warning. However, due to the missing `--all-targets` parameter, the minimal version checks are not performed over all build targets.