### PR TITLE
Update PyO3 to version 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -988,6 +988,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2136,15 +2142,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "1962a33ed2a201c637fc14a4e0fd4e06e6edfdeee6a5fede0dab55507ad74cf7"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset 0.9.1",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -2154,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "ab7164b2202753bd33afc7f90a10355a719aa973d1f94502c50d06f3488bc420"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2164,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "c6424906ca49013c0829c5c1ed405e20e2da2dc78b82d198564880a704e6a7b7"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2174,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "82b2f19e153122d64afd8ce7aaa72f06a00f52e34e1d1e74b6d71baea396460a"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2186,11 +2192,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "dd698c04cac17cf0fe63d47790ab311b8b25542f5cb976b65c374035c50f1eef"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,7 +2155,8 @@ dependencies = [
 [[package]]
 name = "pyo3-build-config"
 version = "0.21.2"
-source = "git+https://github.com/PyO3/pyo3/?rev=2c205d4586bef8f839eb6a55eb91b905074ddce9#2c205d4586bef8f839eb6a55eb91b905074ddce9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,3 @@ members = [
 [patch.crates-io]
 imap-types = { path = "imap-types" }
 imap-codec = { path = "imap-codec" }
-# Package `pyo3-build-config` v0.21.2 specifies its `target-lexicon` dependency with version
-# "0.12", however, only versions from 0.12.6 on will work.
-# This patches `pyo3-build-config` with a version where this dependency has already been fixed
-# until a new version containing this fix has been released.
-# Note: When removing the patch, also remove the corresponding entry in `deny.toml`. (see #516)
-pyo3-build-config = { git = "https://github.com/PyO3/pyo3/", rev = "2c205d4586bef8f839eb6a55eb91b905074ddce9" }

--- a/bindings/imap-codec-python/Cargo.toml
+++ b/bindings/imap-codec-python/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-pyo3 = "0.21.2"
+pyo3 = "0.22.0"

--- a/deny.toml
+++ b/deny.toml
@@ -4,8 +4,6 @@ unknown-git = "deny"
 allow-git = [
     # Used in benchmarking
     "https://github.com/stalwartlabs/mail-server?rev=53f0222f308b3e844c158fc0e603d10361da3c63",
-    # Used for patching `pyo3-build-config` (see #516)
-    "https://github.com/PyO3/pyo3/?rev=2c205d4586bef8f839eb6a55eb91b905074ddce9",
 ]
 
 [licenses]


### PR DESCRIPTION
This updates PyO3 to version 0.22.0 and removes the temporary patch for fixing the sub-dependency version requirement.

This closes #516 .