### PR TITLE
refactor: Hide `bounded_static` from API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,11 +329,6 @@ name = "bounded-static"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0beb903daa49b43bcafb5d5eebe633f9ad638d8b16cd08f95fb05ee7bd099321"
-dependencies = [
- "ahash",
- "bounded-static-derive",
- "chrono",
-]
 
 [[package]]
 name = "bounded-static-derive"
@@ -1207,7 +1202,6 @@ version = "2.0.0-alpha.1"
 dependencies = [
  "abnf-core",
  "base64 0.22.1",
- "bounded-static",
  "chrono",
  "imap-types",
  "log",
@@ -1260,6 +1254,7 @@ dependencies = [
  "arbitrary",
  "base64 0.22.1",
  "bounded-static",
+ "bounded-static-derive",
  "chrono",
  "criterion",
  "rand",
@@ -3071,7 +3066,6 @@ dependencies = [
 name = "tokio-support"
 version = "0.1.0"
 dependencies = [
- "bounded-static",
  "bytes",
  "imap-codec",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,3 @@ members = [
     "assets/demos/tokio-client",
     "assets/demos/tokio-server",
 ]
-
-[patch.crates-io]
-imap-types = { path = "imap-types" }
-imap-codec = { path = "imap-codec" }

--- a/assets/demos/tokio-support/Cargo.toml
+++ b/assets/demos/tokio-support/Cargo.toml
@@ -8,8 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bytes = "1.6.0"
-bounded-static = "0.8.0"
 thiserror = "1.0.61"
 tokio-util = { version = "0.7.11", features = ["codec"] }
 
-imap-codec = { path = "../../../imap-codec", features = ["bounded-static"] }
+imap-codec = { path = "../../../imap-codec" }

--- a/assets/demos/tokio-support/src/client.rs
+++ b/assets/demos/tokio-support/src/client.rs
@@ -1,6 +1,5 @@
 use std::io::{Error as IoError, Write};
 
-use bounded_static::IntoBoundedStatic;
 use bytes::{Buf, BufMut, BytesMut};
 use imap_codec::{
     decode::{Decoder, GreetingDecodeError, ResponseDecodeError},
@@ -9,6 +8,7 @@ use imap_codec::{
         command::Command,
         response::{Greeting, Response},
         state::{State as ImapState, State},
+        IntoStatic,
     },
     CommandCodec, GreetingCodec, ResponseCodec,
 };

--- a/assets/demos/tokio-support/src/server.rs
+++ b/assets/demos/tokio-support/src/server.rs
@@ -1,6 +1,5 @@
 use std::io::{Error as IoError, Write};
 
-use bounded_static::IntoBoundedStatic;
 use bytes::{Buf, BufMut, BytesMut};
 use imap_codec::{
     decode::{CommandDecodeError, Decoder},
@@ -8,6 +7,7 @@ use imap_codec::{
     imap_types::{
         command::Command,
         response::{Greeting, Response},
+        IntoStatic,
     },
     CommandCodec, GreetingCodec, ResponseCodec,
 };

--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -15,12 +15,10 @@ exclude = [
 [features]
 default = ["quirk_rectify_numbers", "quirk_missing_text", "quirk_trailing_space"]
 
-# <Forward to imap-types>
-bounded-static = ["dep:bounded-static", "imap-types/bounded-static"]
-
 # Expose internal parsers for fuzzing
 fuzz = []
 
+# <Forward to imap-types>
 # IMAP
 starttls = ["imap-types/starttls"]
 
@@ -63,9 +61,8 @@ quirk_trailing_space = []
 [dependencies]
 abnf-core = "0.6.0"
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
-bounded-static = { version = "0.8.0", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
-imap-types = { version = "2.0.0-alpha.1", default-features = false, features = ["unvalidated"] }
+imap-types = { version = "2.0.0-alpha.1", path = "../imap-types", default-features = false, features = ["unvalidated"] }
 nom = { version = "7", default-features = false }
 log = { version = "0.4.22", default-features = false }
 

--- a/imap-codec/src/codec.rs
+++ b/imap-codec/src/codec.rs
@@ -206,7 +206,6 @@ mod tests {
             dbg!((std::str::from_utf8(test).unwrap(), &expected, &got));
             assert_eq!(expected, got);
 
-            #[cfg(feature = "bounded-static")]
             {
                 let got = GreetingCodec::default().decode_static(test);
                 assert_eq!(expected, got);
@@ -257,7 +256,6 @@ mod tests {
             dbg!((std::str::from_utf8(test).unwrap(), &expected, &got));
             assert_eq!(expected, got);
 
-            #[cfg(feature = "bounded-static")]
             {
                 let got = CommandCodec::default().decode_static(test);
                 assert_eq!(expected, got);
@@ -302,7 +300,6 @@ mod tests {
             dbg!((std::str::from_utf8(test).unwrap(), &expected, &got));
             assert_eq!(expected, got);
 
-            #[cfg(feature = "bounded-static")]
             {
                 let got = ResponseCodec::default().decode_static(test);
                 assert_eq!(expected, got);

--- a/imap-types/Cargo.toml
+++ b/imap-types/Cargo.toml
@@ -15,7 +15,6 @@ exclude = [
 [features]
 arbitrary = ["dep:arbitrary", "unvalidated", "chrono/arbitrary", "chrono/std"]
 arbitrary_simplified = ["arbitrary"]
-bounded-static = ["dep:bounded-static", "bounded-static/derive"]
 serde = ["dep:serde", "chrono/serde"]
 
 # IMAP
@@ -37,7 +36,8 @@ unvalidated = []
 [dependencies]
 arbitrary = { version = "1.3.2", optional = true, default-features = false, features = ["derive"] }
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
-bounded-static = { version = "0.8.0", default-features = false, features = ["alloc"], optional = true }
+bounded-static = { version = "0.8.0", default-features = false, features = ["alloc"] }
+bounded-static-derive = { version = "0.8.0", default-features = false }
 chrono = { version = "0.4", default-features = false }
 serde = { version = "1.0.204", features = ["derive"], optional = true }
 thiserror = "1.0.61"

--- a/imap-types/fuzz/Cargo.toml
+++ b/imap-types/fuzz/Cargo.toml
@@ -42,7 +42,7 @@ debug = []
 
 [dependencies]
 libfuzzer-sys = "0.4"
-imap-types = { path = "..", default-features = false, features = ["arbitrary", "bounded-static", "unvalidated"] }
+imap-types = { path = "..", default-features = false, features = ["arbitrary", "unvalidated"] }
 
 [[bin]]
 name = "into_static"

--- a/imap-types/fuzz/fuzz_targets/into_static.rs
+++ b/imap-types/fuzz/fuzz_targets/into_static.rs
@@ -1,9 +1,9 @@
 #![no_main]
 
 use imap_types::{
-    bounded_static::IntoBoundedStatic,
     command::Command,
     response::{Greeting, Response},
+    IntoStatic,
 };
 use libfuzzer_sys::fuzz_target;
 

--- a/imap-types/fuzz/fuzz_targets/to_static.rs
+++ b/imap-types/fuzz/fuzz_targets/to_static.rs
@@ -1,9 +1,9 @@
 #![no_main]
 
 use imap_types::{
-    bounded_static::ToBoundedStatic,
     command::Command,
     response::{Greeting, Response},
+    ToStatic,
 };
 use libfuzzer_sys::fuzz_target;
 

--- a/imap-types/src/arbitrary.rs
+++ b/imap-types/src/arbitrary.rs
@@ -480,13 +480,12 @@ impl<'a> Arbitrary<'a> for NaiveDate {
 #[cfg(test)]
 mod tests {
     use arbitrary::{Arbitrary, Error, Unstructured};
-    #[cfg(feature = "bounded-static")]
-    use bounded_static::{IntoBoundedStatic, ToBoundedStatic};
     use rand::{rngs::SmallRng, Rng, SeedableRng};
 
     use crate::{
         command::Command,
         response::{Greeting, Response},
+        IntoStatic, ToStatic,
     };
 
     /// Note: We could encode/decode/etc. here but only want to exercise the arbitrary logic itself.
@@ -505,7 +504,6 @@ mod tests {
                     Ok(_out) => {
                         count += 1;
 
-                        #[cfg(feature = "bounded-static")]
                         {
                             let out_to_static = _out.to_static();
                             assert_eq!(_out, out_to_static);

--- a/imap-types/src/auth.rs
+++ b/imap-types/src/auth.rs
@@ -8,8 +8,7 @@ use std::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -20,9 +19,8 @@ use crate::{
 };
 
 /// Authentication mechanism.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum AuthMechanism<'a> {
     /// The PLAIN SASL mechanism.
@@ -198,18 +196,16 @@ impl FromStr for AuthMechanism<'static> {
 /// An (unknown) authentication mechanism.
 ///
 /// It's guaranteed that this type can't represent any mechanism from [`AuthMechanism`].
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct AuthMechanismOther<'a>(Atom<'a>);
 
 /// Data line used, e.g., during AUTHENTICATE.
 ///
 /// Holds the raw binary data, i.e., a `Vec<u8>`, *not* the BASE64 string.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum AuthenticateData<'a> {
     /// Continue SASL authentication.
     Continue(Secret<Cow<'a, [u8]>>),

--- a/imap-types/src/body.rs
+++ b/imap-types/src/body.rs
@@ -2,8 +2,7 @@
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -14,9 +13,8 @@ use crate::{
 
 /// Inner part of [`BodyStructure`].
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Body<'a> {
     /// Basic fields
     pub basic: BasicFields<'a>,
@@ -26,9 +24,8 @@ pub struct Body<'a> {
 
 /// Basic fields of a non-multipart body part.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct BasicFields<'a> {
     /// List of attribute/value pairs ([MIME-IMB].)
     pub parameter_list: Vec<(IString<'a>, IString<'a>)>,
@@ -51,9 +48,8 @@ pub struct BasicFields<'a> {
 
 /// Specific fields of a non-multipart body part.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum SpecificFields<'a> {
     /// # Example (not in RFC)
     ///
@@ -169,9 +165,8 @@ pub enum SpecificFields<'a> {
 }
 
 /// The BODY(STRUCTURE).
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum BodyStructure<'a> {
     /// For example, a simple text message of 48 lines and 2279 octets
     /// can have a body structure of:
@@ -253,9 +248,8 @@ pub enum BodyStructure<'a> {
 
 /// The extension data of a non-multipart body part.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct SinglePartExtensionData<'a> {
     /// A string giving the body MD5 value as defined in \[MD5\].
     pub md5: NString<'a>,
@@ -279,9 +273,8 @@ pub struct SinglePartExtensionData<'a> {
 /// )
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct MultiPartExtensionData<'a> {
     /// A parenthesized list of attribute/value pairs [e.g., ("foo"
     /// "bar" "baz" "rag") where "bar" is the value of "foo", and
@@ -294,9 +287,8 @@ pub struct MultiPartExtensionData<'a> {
 
 /// Helper to enforce correct usage of [`SinglePartExtensionData`] and [`MultiPartExtensionData`].
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Disposition<'a> {
     /// A parenthesized list, consisting of a disposition type
     /// string, followed by a parenthesized list of disposition
@@ -309,9 +301,8 @@ pub struct Disposition<'a> {
 
 /// Helper to enforce correct usage of [`SinglePartExtensionData`] and [`MultiPartExtensionData`].
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Language<'a> {
     /// A string or parenthesized list giving the body language
     /// value as defined in [LANGUAGE-TAGS].
@@ -323,9 +314,8 @@ pub struct Language<'a> {
 
 /// Helper to enforce correct usage of [`SinglePartExtensionData`] and [`MultiPartExtensionData`].
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Location<'a> {
     /// A string list giving the body content URI as defined in \[LOCATION\].
     pub location: NString<'a>,
@@ -335,9 +325,8 @@ pub struct Location<'a> {
 }
 
 /// Helper to enforce correct usage of [`SinglePartExtensionData`] and [`MultiPartExtensionData`].
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum BodyExtension<'a> {
     /// NString.
     NString(NString<'a>),

--- a/imap-types/src/command.rs
+++ b/imap-types/src/command.rs
@@ -6,8 +6,7 @@ use std::borrow::Cow;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -36,9 +35,8 @@ use crate::{
 
 /// Command.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Command<'a> {
     /// Tag.
     pub tag: Tag<'a>,
@@ -68,9 +66,8 @@ impl<'a> Command<'a> {
 ///
 /// This enum is used to encode all the different commands.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum CommandBody<'a> {
     // ----- Any State (see https://tools.ietf.org/html/rfc3501#section-6.1) -----
     /// ### 6.1.1.  CAPABILITY Command

--- a/imap-types/src/core.rs
+++ b/imap-types/src/core.rs
@@ -43,8 +43,7 @@ use std::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -96,10 +95,9 @@ use crate::extensions::binary::Literal8;
 ///                    ; " (Double Quote)
 /// resp-specials   = "]"
 /// ```
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String"))]
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash, ToStatic)]
 pub struct Atom<'a>(pub(crate) Cow<'a, str>);
 
 // We want a slightly more dense `Debug` implementation.
@@ -249,10 +247,9 @@ impl<'a> Display for Atom<'a> {
 /// ;              |           Additionally allowed in `AtomExt`
 /// ;              See `Atom`
 /// ```
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String"))]
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct AtomExt<'a>(pub(crate) Cow<'a, str>);
 
 // We want a slightly more dense `Debug` implementation.
@@ -384,9 +381,8 @@ impl<'a> AsRef<str> for AtomExt<'a> {
 /// ;        See `Quoted`
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum IString<'a> {
     /// Literal, see [`Literal`].
     Literal(Literal<'a>),
@@ -500,9 +496,8 @@ impl<'a> AsRef<[u8]> for IString<'a> {
 /// CHAR8   = %x01-ff
 ///           ; any OCTET except NUL, %x00
 /// ```
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Literal<'a> {
     #[cfg_attr(
         feature = "serde",
@@ -714,9 +709,8 @@ impl<'a> AsRef<[u8]> for Literal<'a> {
 
 /// Literal mode, i.e., sync or non-sync.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ToStatic)]
 pub enum LiteralMode {
     /// A synchronizing literal, i.e., `{<n>}\r\n<data>`.
     Sync,
@@ -750,10 +744,9 @@ pub enum LiteralMode {
 ///                   ; linefeed
 /// quoted-specials = DQUOTE / "\"
 /// ```
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String"))]
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Quoted<'a>(pub(crate) Cow<'a, str>);
 
 impl<'a> Debug for Quoted<'a> {
@@ -871,9 +864,8 @@ impl<'a> AsRef<str> for Quoted<'a> {
 /// nil     = "NIL"
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct NString<'a>(
     // This wrapper is merely used for formatting.
     // The inner value can be public.
@@ -926,9 +918,8 @@ impl<'a> From<Quoted<'a>> for NString<'a> {
 /// ;         See `AtomExt`
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum AString<'a> {
     // `1*ATOM-CHAR` does not allow resp-specials, but `1*ASTRING-CHAR` does ... :-/
     Atom(AtomExt<'a>),   // 1*ASTRING-CHAR /
@@ -1041,10 +1032,9 @@ impl<'a> AsRef<[u8]> for AString<'a> {
 ///                    ; " (Double Quote)
 /// resp-specials   = "]"
 /// ```
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String"))]
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, ToStatic)]
 pub struct Tag<'a>(pub(crate) Cow<'a, str>);
 
 // We want a slightly more dense `Debug` implementation.
@@ -1171,10 +1161,9 @@ impl<'a> AsRef<str> for Tag<'a> {
 /// CR        = %x0D                        ; carriage return
 /// LF        = %x0A                        ; linefeed
 /// ```
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String"))]
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, ToStatic)]
 pub struct Text<'a>(pub(crate) Cow<'a, str>);
 
 // We want a slightly more dense `Debug` implementation.
@@ -1301,10 +1290,9 @@ impl<'a> AsRef<str> for Text<'a> {
 /// quoted-specials = DQUOTE / "\"
 /// DQUOTE          =  %x22                       ; " (Double Quote)
 /// ```
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "char"))]
-#[derive(Copy, Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Copy, Debug, PartialEq, Eq, Hash, Clone, ToStatic)]
 pub struct QuotedChar(char);
 
 impl QuotedChar {
@@ -1379,9 +1367,8 @@ impl TryFrom<char> for QuotedChar {
 /// DIGIT              = "0".."9" ; Numeric digit
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Charset<'a> {
     Atom(Atom<'a>),
     Quoted(Quoted<'a>),
@@ -1460,9 +1447,8 @@ impl<'a> AsRef<str> for Charset<'a> {
 
 #[cfg(any(feature = "ext_binary", feature = "ext_metadata"))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub enum NString8<'a> {
     NString(NString<'a>),
     Literal8(Literal8<'a>),
@@ -1477,10 +1463,9 @@ pub enum NString8<'a> {
 ///
 /// * `Vec<T, 0>` must not be used. Please use the standard [`Vec`] instead.
 /// * `Vec<T, 1>` must not be used. Please use the alias [`Vec1<T>`] instead.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "Vec<T>"))]
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct VecN<T, const N: usize>(pub(crate) Vec<T>);
 
 impl<T, const N: usize> Debug for VecN<T, N>

--- a/imap-types/src/datetime.rs
+++ b/imap-types/src/datetime.rs
@@ -2,7 +2,6 @@
 
 use std::fmt::{Debug, Formatter};
 
-#[cfg(feature = "bounded-static")]
 use bounded_static::{IntoBoundedStatic, ToBoundedStatic};
 use chrono::{Datelike, FixedOffset};
 #[cfg(feature = "serde")]
@@ -78,7 +77,6 @@ impl AsRef<chrono::DateTime<FixedOffset>> for DateTime {
     }
 }
 
-#[cfg(feature = "bounded-static")]
 impl IntoBoundedStatic for DateTime {
     type Static = Self;
 
@@ -87,7 +85,6 @@ impl IntoBoundedStatic for DateTime {
     }
 }
 
-#[cfg(feature = "bounded-static")]
 impl ToBoundedStatic for DateTime {
     type Static = Self;
 
@@ -152,7 +149,6 @@ impl AsRef<chrono::NaiveDate> for NaiveDate {
     }
 }
 
-#[cfg(feature = "bounded-static")]
 impl IntoBoundedStatic for NaiveDate {
     type Static = Self;
 
@@ -161,7 +157,6 @@ impl IntoBoundedStatic for NaiveDate {
     }
 }
 
-#[cfg(feature = "bounded-static")]
 impl ToBoundedStatic for NaiveDate {
     type Static = Self;
 

--- a/imap-types/src/envelope.rs
+++ b/imap-types/src/envelope.rs
@@ -2,17 +2,15 @@
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::core::NString;
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Envelope<'a> {
     pub date: NString<'a>,
     pub subject: NString<'a>,
@@ -28,9 +26,8 @@ pub struct Envelope<'a> {
 
 /// An address structure describes an electronic mail address.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 /// TODO(misuse):
 ///
 ///   Here are many invariants ...

--- a/imap-types/src/extensions/binary.rs
+++ b/imap-types/src/extensions/binary.rs
@@ -7,8 +7,7 @@ use std::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -16,9 +15,8 @@ use crate::core::{Literal, LiteralMode};
 
 /// Either a [`Literal`] or [`Literal8`].
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, ToStatic)]
 pub enum LiteralOrLiteral8<'a> {
     Literal(Literal<'a>),
     Literal8(Literal8<'a>),
@@ -26,9 +24,8 @@ pub enum LiteralOrLiteral8<'a> {
 
 /// String that might contain NULs.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Literal8<'a> {
     pub data: Cow<'a, [u8]>,
     /// Specifies whether this is a synchronizing or non-synchronizing literal.

--- a/imap-types/src/extensions/compress.rs
+++ b/imap-types/src/extensions/compress.rs
@@ -14,8 +14,7 @@ use std::fmt::{Display, Formatter};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -35,9 +34,8 @@ impl<'a> CommandBody<'a> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum CompressionAlgorithm {
     Deflate,

--- a/imap-types/src/extensions/enable.rs
+++ b/imap-types/src/extensions/enable.rs
@@ -10,8 +10,7 @@ use std::fmt::{Display, Formatter};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -35,9 +34,8 @@ impl<'a> CommandBody<'a> {
     }
 }
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum CapabilityEnable<'a> {
     Utf8(Utf8Kind),
@@ -95,15 +93,13 @@ impl<'a> Display for CapabilityEnable<'a> {
 /// An (unknown) capability.
 ///
 /// It's guaranteed that this type can't represent any capability from [`CapabilityEnable`].
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct CapabilityEnableOther<'a>(Atom<'a>);
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum Utf8Kind {
     Accept,

--- a/imap-types/src/extensions/idle.rs
+++ b/imap-types/src/extensions/idle.rs
@@ -15,14 +15,12 @@
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Denotes the continuation data message "DONE\r\n" to end the IDLE command.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct IdleDone;

--- a/imap-types/src/extensions/metadata.rs
+++ b/imap-types/src/extensions/metadata.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -11,9 +10,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub struct EntryValue<'a> {
     pub entry: Entry<'a>,
     pub value: NString8<'a>,
@@ -21,9 +19,8 @@ pub struct EntryValue<'a> {
 
 /// Slash-separated path to entry.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub struct Entry<'a>(AString<'a>);
 
 impl<'a> Entry<'a> {
@@ -49,9 +46,8 @@ impl AsRef<[u8]> for Entry<'_> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub enum GetMetadataOption {
     /// Only return values that are less than or equal in octet size to the specified limit.
     ///
@@ -66,9 +62,8 @@ pub enum GetMetadataOption {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub enum Depth {
     /// No entries below the specified entry are returned
     Null,
@@ -79,9 +74,8 @@ pub enum Depth {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub enum MetadataCode {
     LongEntries(u32),
     MaxSize(u32),
@@ -90,9 +84,8 @@ pub enum MetadataCode {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub enum MetadataResponse<'a> {
     WithValues(Vec1<EntryValue<'a>>),
     WithoutValues(Vec1<Entry<'a>>),

--- a/imap-types/src/extensions/quota.rs
+++ b/imap-types/src/extensions/quota.rs
@@ -40,8 +40,7 @@ use std::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -123,9 +122,8 @@ impl<'a> Data<'a> {
 /// A resource type for use in IMAP's QUOTA extension.
 ///
 /// Supported resource names MUST be advertised as a capability by prepending the resource name with "QUOTA=RES-".
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Resource<'a> {
     /// The physical space estimate, in units of 1024 octets, of the mailboxes governed by the quota
     /// root.
@@ -185,9 +183,8 @@ pub enum Resource<'a> {
 /// An (unknown) resource.
 ///
 /// It's guaranteed that this type can't represent any resource from [`Resource`].
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct ResourceOther<'a>(Atom<'a>);
 
 impl_try_from!(Atom<'a>, 'a, &'a [u8], Resource<'a>);
@@ -223,9 +220,8 @@ impl<'a> Display for Resource<'a> {
 /// A type that holds a resource name, usage, and limit.
 /// Used in the response of the GETQUOTA command.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct QuotaGet<'a> {
     pub resource: Resource<'a>,
     pub usage: u64,
@@ -245,9 +241,8 @@ impl<'a> QuotaGet<'a> {
 /// A type that holds a resource name and limit.
 /// Used in the SETQUOTA command.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(ToStatic, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QuotaSet<'a> {
     pub resource: Resource<'a>,
     pub limit: u64,

--- a/imap-types/src/extensions/sort.rs
+++ b/imap-types/src/extensions/sort.rs
@@ -2,8 +2,7 @@ use std::fmt::{Display, Formatter};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -11,9 +10,8 @@ use serde::{Deserialize, Serialize};
 use crate::arbitrary::impl_arbitrary_try_from;
 use crate::core::Atom;
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum SortAlgorithm<'a> {
     Display,
     Other(SortAlgorithmOther<'a>),
@@ -40,9 +38,8 @@ impl Display for SortAlgorithm<'_> {
 #[cfg(feature = "arbitrary")]
 impl_arbitrary_try_from! { SortAlgorithm<'a>, Atom<'a> }
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct SortAlgorithmOther<'a>(Atom<'a>);
 
 impl AsRef<str> for SortAlgorithmOther<'_> {
@@ -52,18 +49,16 @@ impl AsRef<str> for SortAlgorithmOther<'_> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct SortCriterion {
     pub reverse: bool,
     pub key: SortKey,
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum SortKey {
     Arrival,
     Cc,

--- a/imap-types/src/extensions/thread.rs
+++ b/imap-types/src/extensions/thread.rs
@@ -5,8 +5,7 @@ use std::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -14,9 +13,8 @@ use serde::{Deserialize, Serialize};
 use crate::arbitrary::impl_arbitrary_try_from;
 use crate::core::{Atom, Vec1, Vec2};
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Thread {
     Members {
         prefix: Vec1<NonZeroU32>,
@@ -140,9 +138,8 @@ fn arbitrary_thread_leaf(u: &mut Unstructured) -> arbitrary::Result<Thread> {
     })
 }
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum ThreadingAlgorithm<'a> {
     OrderedSubject,
     References,
@@ -172,9 +169,8 @@ impl Display for ThreadingAlgorithm<'_> {
 #[cfg(feature = "arbitrary")]
 impl_arbitrary_try_from! { ThreadingAlgorithm<'a>, Atom<'a> }
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct ThreadingAlgorithmOther<'a>(Atom<'a>);
 
 impl<'a> AsRef<str> for ThreadingAlgorithmOther<'a> {

--- a/imap-types/src/extensions/uidplus.rs
+++ b/imap-types/src/extensions/uidplus.rs
@@ -2,23 +2,20 @@ use std::num::NonZeroU32;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::core::Vec1;
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct UidSet(pub Vec1<UidElement>);
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum UidElement {
     Single(NonZeroU32),
     Range(NonZeroU32, NonZeroU32),

--- a/imap-types/src/fetch.rs
+++ b/imap-types/src/fetch.rs
@@ -7,8 +7,7 @@ use std::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -24,9 +23,8 @@ use crate::{
 
 /// Shorthands for commonly-used message data items.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum Macro {
     /// Shorthand for `(FLAGS INTERNALDATE RFC822.SIZE)`.
@@ -63,9 +61,8 @@ impl Display for Macro {
 ///
 /// A macro must be used by itself, and not in conjunction with other macros or data items.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum MacroOrMessageDataItemNames<'a> {
     Macro(Macro),
     MessageDataItemNames(Vec<MessageDataItemName<'a>>),
@@ -85,9 +82,8 @@ impl<'a> From<Vec<MessageDataItemName<'a>>> for MacroOrMessageDataItemNames<'a> 
 
 /// Message data item name used to request a message data item.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[doc(alias = "FetchAttribute")]
 pub enum MessageDataItemName<'a> {
     /// Non-extensible form of `BODYSTRUCTURE`.
@@ -245,9 +241,8 @@ pub enum MessageDataItemName<'a> {
 
 /// Message data item.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[doc(alias = "FetchAttributeValue")]
 pub enum MessageDataItem<'a> {
     /// A form of `BODYSTRUCTURE` without extension data.
@@ -424,9 +419,8 @@ pub enum MessageDataItem<'a> {
 /// 4.2.2.2    TEXT/RICHTEXT
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Section<'a> {
     Part(Part),
 
@@ -449,9 +443,8 @@ pub enum Section<'a> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Part(pub Vec1<NonZeroU32>);
 
 /// A part specifier is either a part number or one of the following:
@@ -469,9 +462,8 @@ pub struct Part(pub Vec1<NonZeroU32>);
 /// and the body; the blank line is included in all header fetches,
 /// except in the case of a message which has no body and no blank
 /// line.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum PartSpecifier<'a> {
     PartNumber(u32),
     Header,

--- a/imap-types/src/flag.rs
+++ b/imap-types/src/flag.rs
@@ -4,8 +4,7 @@ use std::fmt::{Display, Formatter};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -23,9 +22,8 @@ use crate::{core::Atom, error::ValidationError};
 /// in the mailbox by sending the `\*` flag ([`FlagPerm::Asterisk`]) in the PERMANENTFLAGS response..
 ///
 /// Note that a flag of either type can be permanent or session-only.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Flag<'a> {
     /// Message has been answered (`\Answered`).
     Answered,
@@ -46,9 +44,8 @@ pub enum Flag<'a> {
 /// An (extension) flag.
 ///
 /// It's guaranteed that this type can't represent any flag from [`Flag`].
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct FlagExtension<'a>(Atom<'a>);
 
 impl<'a> Flag<'a> {
@@ -95,9 +92,8 @@ impl<'a> Display for Flag<'a> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum FlagFetch<'a> {
     Flag(Flag<'a>),
 
@@ -111,9 +107,8 @@ pub enum FlagFetch<'a> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum FlagPerm<'a> {
     Flag(Flag<'a>),
 
@@ -123,9 +118,8 @@ pub enum FlagPerm<'a> {
 }
 
 /// Four name attributes are defined.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum FlagNameAttribute<'a> {
     /// It is not possible for any child levels of hierarchy to exist
     /// under this name; no child levels exist now and none can be
@@ -149,9 +143,8 @@ pub enum FlagNameAttribute<'a> {
 }
 
 /// An extension flag.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct FlagNameAttributeExtension<'a>(Atom<'a>);
 
 impl<'a> FlagNameAttribute<'a> {
@@ -188,9 +181,8 @@ impl<'a> Display for FlagNameAttribute<'a> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ToStatic)]
 pub enum StoreType {
     Replace,
     Add,
@@ -198,9 +190,8 @@ pub enum StoreType {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ToStatic)]
 pub enum StoreResponse {
     Answer,
     Silent,

--- a/imap-types/src/mailbox.rs
+++ b/imap-types/src/mailbox.rs
@@ -4,8 +4,7 @@ use std::{borrow::Cow, str::from_utf8};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -16,10 +15,9 @@ use crate::{
     utils::indicators::is_list_char,
 };
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String"))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct ListCharString<'a>(pub(crate) Cow<'a, str>);
 
 impl<'a> ListCharString<'a> {
@@ -91,9 +89,8 @@ impl<'a> AsRef<[u8]> for ListCharString<'a> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum ListMailbox<'a> {
     Token(ListCharString<'a>),
     String(IString<'a>),
@@ -174,9 +171,8 @@ impl<'a> TryFrom<String> for ListMailbox<'a> {
 ///    levels of hierarchy.
 /// 5) Two characters, "#" and "&", have meanings by convention, and should be avoided except
 ///    when used in that convention.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Mailbox<'a> {
     Inbox,
     Other(MailboxOther<'a>),
@@ -199,10 +195,9 @@ impl<'a> From<AString<'a>> for Mailbox<'a> {
 // We do not implement `AsRef<...>` for `Mailbox` because we want to enforce that a consumer
 // `match`es on `Mailbox::Inbox`/`Mailbox::Other`.
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "AString<'a>"))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct MailboxOther<'a>(pub(crate) AString<'a>);
 
 impl<'a> MailboxOther<'a> {

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -9,8 +9,7 @@ use std::{
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 use base64::{engine::general_purpose::STANDARD as _base64, Engine};
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -44,9 +43,8 @@ use crate::{
 ///
 /// Note: Don't use `code: None` *and* a `text` that starts with "[" as this would be ambiguous in IMAP.
 /// We could fix this but the fix would make this type unconformable to use.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Greeting<'a> {
     pub kind: GreetingKind,
     pub code: Option<Code<'a>>,
@@ -92,9 +90,8 @@ impl<'a> Greeting<'a> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ToStatic)]
 /// IMAP4rev1 defines three possible greetings at connection startup.
 pub enum GreetingKind {
     /// The connection is not yet authenticated.
@@ -113,9 +110,8 @@ pub enum GreetingKind {
 
 /// Response.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Response<'a> {
     /// Command continuation request responses use the token "+" instead of a
     /// tag.  These responses are sent by the server to indicate acceptance
@@ -134,9 +130,8 @@ pub enum Response<'a> {
 }
 
 /// Status response.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Status<'a> {
     Untagged(StatusBody<'a>),
     Tagged(Tagged<'a>),
@@ -147,9 +142,8 @@ pub enum Status<'a> {
 ///
 /// Note: Don't use `code: None` *and* a `text` that starts with "[" as this would be ambiguous in IMAP.
 /// We could fix this but the fix would make this type unconformable to use.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct StatusBody<'a> {
     /// Status kind.
     pub kind: StatusKind,
@@ -163,9 +157,8 @@ pub struct StatusBody<'a> {
 
 /// Status kind.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ToStatic)]
 pub enum StatusKind {
     /// Indicates an information from the server.
     ///
@@ -184,9 +177,8 @@ pub enum StatusKind {
     Bad,
 }
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Tagged<'a> {
     pub tag: Tag<'a>,
     pub body: StatusBody<'a>,
@@ -218,9 +210,8 @@ pub struct Tagged<'a> {
 /// continue to read response data from the server until the
 /// connection is closed; this will ensure that any pending untagged
 /// or completion responses are read and processed.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct Bye<'a> {
     pub code: Option<Code<'a>>,
     pub text: Text<'a>,
@@ -316,9 +307,8 @@ impl<'a> Status<'a> {
 
 /// ## 7.2 - 7.4 Server and Mailbox Status; Mailbox Size; Message Status
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Data<'a> {
     // ## 7.2. Server Responses - Server and Mailbox Status
     //
@@ -653,9 +643,8 @@ impl<'a> Data<'a> {
 /// additional command arguments, the literal octets are followed by a
 /// space and those arguments.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[doc(alias = "Continue")]
 #[doc(alias = "Continuation")]
 #[doc(alias = "ContinuationRequest")]
@@ -682,13 +671,12 @@ impl<'a> CommandContinuationRequest<'a> {
     }
 }
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
     serde(try_from = "CommandContinuationRequestBasicShadow")
 )]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct CommandContinuationRequestBasic<'a> {
     code: Option<Code<'a>>,
     text: Text<'a>,
@@ -758,9 +746,8 @@ impl<'a> CommandContinuationRequestBasic<'a> {
 ///
 /// The currently defined response codes are:
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Code<'a> {
     /// `ALERT`
     ///
@@ -946,9 +933,8 @@ impl<'a> Code<'a> {
 /// An (unknown) code.
 ///
 /// It's guaranteed that this type can't represent any code from [`Code`].
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct CodeOther<'a>(Cow<'a, [u8]>);
 
 // We want a more readable `Debug` implementation.
@@ -992,9 +978,8 @@ impl<'a> CodeOther<'a> {
     }
 }
 
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum Capability<'a> {
     Imap4Rev1,
@@ -1212,9 +1197,8 @@ impl<'a> From<Atom<'a>> for Capability<'a> {
 /// An (unknown) capability.
 ///
 /// It's guaranteed that this type can't represent any capability from [`Capability`].
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct CapabilityOther<'a>(Atom<'a>);
 
 /// Error-related types.

--- a/imap-types/src/search.rs
+++ b/imap-types/src/search.rs
@@ -1,7 +1,6 @@
 //! Search-related types.
 
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -12,9 +11,8 @@ use crate::{
 };
 
 /// The defined search keys.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum SearchKey<'a> {
     // <Not in RFC.>
     //

--- a/imap-types/src/secret.rs
+++ b/imap-types/src/secret.rs
@@ -7,16 +7,14 @@ use std::fmt::{Debug, Formatter};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A wrapper to ensure that secrets are redacted during `Debug`-printing.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq, ToStatic)]
 pub struct Secret<T>(T);
 
 impl<T> Secret<T> {

--- a/imap-types/src/sequence.rs
+++ b/imap-types/src/sequence.rs
@@ -10,8 +10,7 @@ use std::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -31,9 +30,8 @@ pub const MAX: NonZeroU32 = match NonZeroU32::new(u32::MAX) {
 };
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub struct SequenceSet(pub Vec1<Sequence>);
 
 impl From<Sequence> for SequenceSet {
@@ -126,9 +124,8 @@ impl FromStr for SequenceSet {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Sequence {
     Single(SeqOrUid),
     Range(SeqOrUid, SeqOrUid),
@@ -178,9 +175,8 @@ impl FromStr for Sequence {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy, ToStatic)]
 pub enum SeqOrUid {
     Value(NonZeroU32),
     Asterisk,

--- a/imap-types/src/state.rs
+++ b/imap-types/src/state.rs
@@ -50,17 +50,15 @@
 //! (7) LOGOUT command, server shutdown, or connection closed
 //! ```
 
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{core::Tag, mailbox::Mailbox};
 
 /// State of the IMAP4rev1 connection.
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, ToStatic)]
 pub enum State<'a> {
     Greeting,
 
@@ -95,11 +93,8 @@ pub enum State<'a> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "bounded-static")]
-    use bounded_static::{IntoBoundedStatic, ToBoundedStatic};
-
     use super::*;
-    use crate::{core::Tag, mailbox::Mailbox};
+    use crate::{core::Tag, mailbox::Mailbox, IntoStatic, ToStatic};
 
     #[test]
     fn test_conversion() {
@@ -114,7 +109,6 @@ mod tests {
         ];
 
         for _test in tests {
-            #[cfg(feature = "bounded-static")]
             {
                 let test_to_static = _test.to_static();
                 assert_eq!(_test, test_to_static);

--- a/imap-types/src/status.rs
+++ b/imap-types/src/status.rs
@@ -2,16 +2,14 @@ use std::num::NonZeroU32;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-#[cfg(feature = "bounded-static")]
-use bounded_static::ToStatic;
+use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Status data item name used to request a status data item.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[doc(alias = "StatusAttribute")]
 pub enum StatusDataItemName {
     /// The number of messages in the mailbox.
@@ -42,9 +40,8 @@ pub enum StatusDataItemName {
 
 /// Status data item.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(feature = "bounded-static", derive(ToStatic))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[doc(alias = "StatusAttributeValue")]
 pub enum StatusDataItem {
     /// The number of messages in the mailbox.

--- a/justfile
+++ b/justfile
@@ -66,7 +66,6 @@ cargo_hack mode: install_cargo_hack
         --group-features \
         arbitrary,\
         arbitrary_simplified,\
-        bounded-static,\
         serde \
         --group-features \
         starttls,\


### PR DESCRIPTION
This is a quick attempt to remove `bounded_static` from our public API. Mainly, we wrap `bounded_static::{Into,To}BoundedStatic` in `imap_types::{Into,To}Static`. This way, `imap-codec` does not need to know about `bounded_static`. Further, I feel that we almost always want to have `to_static`. Thus, I removed the feature.

Changes:

* Ungate/Remove `bounded-static` feature
* Introduce `imap_types::{ToStatic, IntoStatic}`
* Simplify `#[derive]`s