### PR TITLE
test(imap-codec): add `fragmentizer` fuzz-target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,7 @@ name = "imap-codec"
 version = "2.0.0-alpha.2"
 dependencies = [
  "abnf-core",
+ "arbitrary",
  "base64 0.22.1",
  "chrono",
  "imap-types",

--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 
 [features]
 default = ["quirk_rectify_numbers", "quirk_missing_text", "quirk_trailing_space"]
-
+arbitrary = ["dep:arbitrary"]
 # Expose internal parsers for fuzzing
 fuzz = []
 
@@ -59,6 +59,7 @@ quirk_id_empty_to_nil = []
 quirk_trailing_space = []
 
 [dependencies]
+arbitrary = { version = "1.3.2", optional = true, default-features = false, features = ["derive"] }
 abnf-core = "0.6.0"
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/imap-codec/fuzz/Cargo.toml
+++ b/imap-codec/fuzz/Cargo.toml
@@ -51,60 +51,76 @@ split = []
 
 [dependencies]
 arbitrary = "1.3.2"
-imap-codec = { path = "..", features = ["fuzz"] }
+imap-codec = { path = "..", features = ["arbitrary", "fuzz"] }
 imap-types = { path = "../../imap-types", features = ["arbitrary"] }
 libfuzzer-sys = "0.4"
+
+[[bin]]
+name = "fragmentizer"
+path = "fuzz_targets/fragmentizer.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "greeting"
 path = "fuzz_targets/greeting.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "command"
 path = "fuzz_targets/command.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "response"
 path = "fuzz_targets/response.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "authenticate_data"
 path = "fuzz_targets/authenticate_data.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "greeting_to_bytes_and_back"
 path = "fuzz_targets/greeting_to_bytes_and_back.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "command_to_bytes_and_back"
 path = "fuzz_targets/command_to_bytes_and_back.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "response_to_bytes_and_back"
 path = "fuzz_targets/response_to_bytes_and_back.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "authenticate_data_to_bytes_and_back"
 path = "fuzz_targets/authenticate_data_to_bytes_and_back.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "tags_structured"
 path = "fuzz_targets/tags_structured.rs"
 test = false
 doc = false
+bench = false

--- a/imap-codec/fuzz/fuzz_targets/fragmentizer.rs
+++ b/imap-codec/fuzz/fuzz_targets/fragmentizer.rs
@@ -1,0 +1,48 @@
+#![no_main]
+
+use imap_codec::fragmentizer::{Fragmentizer, MaxMessageSize};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|input: (MaxMessageSize, Vec<&[u8]>)| {
+    let (mms, data) = input;
+
+    #[cfg(feature = "debug")]
+    println!("input: {mms:?}, {data:?}");
+
+    let mut fragmentizer = Fragmentizer::new(mms);
+
+    // Ensure `Fragmentizer` recreates input data (when smaller than `mms`).
+    let mut emitted_bytes = Vec::new();
+    let check_recreation = match mms {
+        MaxMessageSize::Unlimited => true,
+        MaxMessageSize::Limited(limit) => {
+            data.iter().map(|s| s.len()).sum::<usize>() <= limit as usize
+        }
+    };
+
+    for chunk in &data {
+        loop {
+            match fragmentizer.progress() {
+                Some(fragment_info) => {
+                    #[cfg(feature = "debug")]
+                    println!("{fragment_info:?}");
+
+                    if check_recreation {
+                        // Collect emitted bytes.
+                        emitted_bytes.extend_from_slice(fragmentizer.fragment_bytes(fragment_info));
+                    }
+                }
+                None => {
+                    fragmentizer.enqueue_bytes(chunk);
+                    break;
+                }
+            }
+        }
+    }
+
+    if check_recreation {
+        // Ensure emitted bytes are prefix of fuzzing input data.
+        let input = data.into_iter().flat_map(Vec::from).collect::<Vec<u8>>();
+        assert_eq!(input[..emitted_bytes.len()], emitted_bytes);
+    }
+});

--- a/imap-codec/fuzz/fuzz_targets/fragmentizer.rs
+++ b/imap-codec/fuzz/fuzz_targets/fragmentizer.rs
@@ -11,7 +11,7 @@ fuzz_target!(|input: (MaxMessageSize, Vec<Vec<u8>>)| {
 
     // Ensure `Fragmentizer` recreates input data (when smaller than `mms`).
     let mut emitted_bytes = Vec::new();
-    let data_flat = data.iter().flatten().copied().collect::<Vec<u8>>();
+    let data_flat = data.concat();
 
     let mut fragmentizer = Fragmentizer::new(mms);
 

--- a/imap-codec/fuzz/fuzz_targets/fragmentizer.rs
+++ b/imap-codec/fuzz/fuzz_targets/fragmentizer.rs
@@ -3,22 +3,17 @@
 use imap_codec::fragmentizer::{Fragmentizer, MaxMessageSize};
 use libfuzzer_sys::fuzz_target;
 
-fuzz_target!(|input: (MaxMessageSize, Vec<&[u8]>)| {
+fuzz_target!(|input: (MaxMessageSize, Vec<Vec<u8>>)| {
     let (mms, data) = input;
 
     #[cfg(feature = "debug")]
-    println!("input: {mms:?}, {data:?}");
-
-    let mut fragmentizer = Fragmentizer::new(mms);
+    println!("input: mms={mms:?}, data={data:?}");
 
     // Ensure `Fragmentizer` recreates input data (when smaller than `mms`).
     let mut emitted_bytes = Vec::new();
-    let check_recreation = match mms {
-        MaxMessageSize::Unlimited => true,
-        MaxMessageSize::Limited(limit) => {
-            data.iter().map(|s| s.len()).sum::<usize>() <= limit as usize
-        }
-    };
+    let data_flat = data.iter().flatten().copied().collect::<Vec<u8>>();
+
+    let mut fragmentizer = Fragmentizer::new(mms);
 
     for chunk in &data {
         loop {
@@ -27,10 +22,8 @@ fuzz_target!(|input: (MaxMessageSize, Vec<&[u8]>)| {
                     #[cfg(feature = "debug")]
                     println!("{fragment_info:?}");
 
-                    if check_recreation {
-                        // Collect emitted bytes.
-                        emitted_bytes.extend_from_slice(fragmentizer.fragment_bytes(fragment_info));
-                    }
+                    // Collect emitted bytes.
+                    emitted_bytes.extend_from_slice(fragmentizer.fragment_bytes(fragment_info));
                 }
                 None => {
                     fragmentizer.enqueue_bytes(chunk);
@@ -40,9 +33,18 @@ fuzz_target!(|input: (MaxMessageSize, Vec<&[u8]>)| {
         }
     }
 
-    if check_recreation {
+    assert!(emitted_bytes.len() <= data_flat.len());
+
+    let check_prefix = match mms {
+        MaxMessageSize::Unlimited => true,
+        MaxMessageSize::Limited(limit) => data_flat.len() <= limit as usize,
+    };
+
+    if check_prefix {
+        #[cfg(feature = "debug")]
+        println!("Checking prefix...");
+
         // Ensure emitted bytes are prefix of fuzzing input data.
-        let input = data.into_iter().flat_map(Vec::from).collect::<Vec<u8>>();
-        assert_eq!(input[..emitted_bytes.len()], emitted_bytes);
+        assert_eq!(emitted_bytes, data_flat[..emitted_bytes.len()]);
     }
 });

--- a/imap-codec/src/fragmentizer.rs
+++ b/imap-codec/src/fragmentizer.rs
@@ -2,6 +2,8 @@
 
 use std::{collections::VecDeque, ops::Range};
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
 use imap_types::{
     core::{LiteralMode, Tag},
     secret::Secret,
@@ -10,6 +12,7 @@ use imap_types::{
 use crate::decode::Decoder;
 
 /// Limits the size of messages that can be decoded by [`Fragmentizer`].
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum MaxMessageSize {
     /// Message size is not limited.


### PR DESCRIPTION
Run with ...

```bash
cd imap-codec
cargo +nightly fuzz run fragmentizer --features=debug --release -- -dict=fuzz/imap.dict -max_len=128
```

(Remove `--features=debug` to suppress debug output.)