### PR TITLE
docs: add `Fragmentizer` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ $ cargo run --example=parse_command
 
 ... to parse some IMAP messages.
 
+### Robust parsing
+
+Real-world implementations need to handle invalid messages.
+Thus, `imap-codec` provides a `Fragmentizer` (see `fragmentizer*` examples) for "two-stage parsing".
+
+The idea is to detect message boundaries (consuming raw lines and literals) first, and to apply an IMAP message parser
+second.
+If the message parser errors out, we can safely discard the erroneous message w/o affecting other messages because we
+know the message boundaries.
+
+You can try this out by running ...
+
+```sh
+$ cargo run --example=fragmentizer_server
+```
+
+... and connecting via ...
+
+```sh
+$ netcat -C 127.0.0.1 12345
+```
+
 ### Tokio demo
 
 You can also start the [demo server] with ...

--- a/imap-codec/examples/fragmentizer.rs
+++ b/imap-codec/examples/fragmentizer.rs
@@ -1,0 +1,42 @@
+use std::io::{stdin, Read};
+
+use imap_codec::{fragmentizer::Fragmentizer, imap_types::utils::escape_byte_string};
+
+fn main() {
+    let mut fragmentizer = Fragmentizer::new(1024);
+
+    loop {
+        match fragmentizer.progress() {
+            Some(fragment_info) => {
+                println!(
+                    "[!] Fragment: {fragment_info:#?} // b\"{}\"",
+                    escape_byte_string(fragmentizer.fragment_bytes(fragment_info))
+                );
+
+                if fragmentizer.is_message_complete() {
+                    println!(
+                        "[!] Complete message: {}",
+                        escape_byte_string(fragmentizer.message_bytes())
+                    );
+                }
+            }
+            None => {
+                println!("[!] Reading stdin (ctrl+d to flush)...");
+                let mut buffer = [0; 64];
+                let count = stdin().read(&mut buffer).unwrap();
+                if count == 0 {
+                    println!("[!] Connection closed");
+                    break;
+                }
+                let chunk = &buffer[..count];
+
+                println!(
+                    "[!] Enqueueing {} byte(s) (b\"{}\")",
+                    count,
+                    escape_byte_string(chunk)
+                );
+                fragmentizer.enqueue_bytes(chunk);
+            }
+        }
+    }
+}

--- a/imap-codec/src/lib.rs
+++ b/imap-codec/src/lib.rs
@@ -22,11 +22,13 @@
 //! ### Example
 //!
 //! ```rust
-//! // Run 'cargo add imap-types' in your project's root directory.
-//! use imap_codec::{decode::Decoder, GreetingCodec};
-//! use imap_types::{
-//!     core::Text,
-//!     response::{Code, Greeting, GreetingKind},
+//! use imap_codec::{
+//!     decode::Decoder,
+//!     imap_types::{
+//!         core::Text,
+//!         response::{Code, Greeting, GreetingKind},
+//!     },
+//!     GreetingCodec,
 //! };
 //!
 //! let (remaining, greeting) = GreetingCodec::default()
@@ -54,11 +56,13 @@
 //! ### Example
 //!
 //! ```rust
-//! // Run 'cargo add imap-types' in your project's root directory.
-//! use imap_codec::{encode::Encoder, GreetingCodec};
-//! use imap_types::{
-//!     core::Text,
-//!     response::{Code, Greeting, GreetingKind},
+//! use imap_codec::{
+//!     encode::Encoder,
+//!     imap_types::{
+//!         core::Text,
+//!         response::{Code, Greeting, GreetingKind},
+//!     },
+//!     GreetingCodec,
 //! };
 //!
 //! let greeting = Greeting {


### PR DESCRIPTION
Closes #538 

It makes sense to review this commit by commit.

* `docs(imap-codec): improve documentation` is unrelated. Just fixed it as I saw it.
* `style: reorder types according to "fn main first" style` is a pure move of types. imap-codec defines types top-to-bottom. This makes it more consistent.