### PR TITLE
Use separate Python classes for fragment variants

### DIFF
--- a/bindings/imap-codec-python/imap_codec.pyi
+++ b/bindings/imap-codec-python/imap_codec.pyi
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Tuple, Union
 
 class DecodeError(Exception):
     """
@@ -25,6 +25,72 @@ class DecodeLiteralFound(DecodeError):
     The decoder stopped at the beginning of literal data.
     """
 
+class LiteralMode:
+    """
+    Literal mode, i.e., sync or non-sync.
+
+    - Sync: A synchronizing literal, i.e., `{<n>}\r\n<data>`.
+    - NonSync: A non-synchronizing literal according to RFC 7888, i.e., `{<n>+}\r\n<data>`.
+
+    Warning: The non-sync literal extension must only be used when the server advertised support
+             for it sending the LITERAL+ or LITERAL- capability.
+    """
+
+    Sync: LiteralMode
+    NonSync: LiteralMode
+
+class LineFragment:
+    """
+    Fragment of a line that is ready to be send.
+    """
+
+    def __init__(self, data: bytes):
+        """
+        Create a line fragment from data bytes
+
+        :param data: Data bytes of fragment
+        :raises TypeError: `data` is not byte-like
+        """
+
+    @property
+    def data(self) -> bytes:
+        """
+        Get line fragment data bytes
+
+        :return: Data bytes of fragment
+        """
+
+class LiteralFragment:
+    """
+    Fragment of a literal that may require an action before it should be send.
+    """
+
+    def __init__(self, data: bytes, mode: LiteralMode):
+        """
+        Create a literal fragment from data bytes and literal mode
+
+        :param data: Data bytes of fragment
+        :param mode: Literal mode
+        :raises TypeError: `data` is not byte-like
+        :raises TypeError: `mode` is invalid
+        """
+
+    @property
+    def data(self) -> bytes:
+        """
+        Get literal fragment data bytes
+
+        :return: Data bytes of fragment
+        """
+
+    @property
+    def mode(self) -> LiteralMode:
+        """
+        Get literal fragment literal mode
+
+        :return: Literal mode
+        """
+
 class Encoded:
     """
     An encoded message.
@@ -36,7 +102,7 @@ class Encoded:
     """
 
     def __iter__(self) -> Encoded: ...
-    def __next__(self) -> dict: ...
+    def __next__(self) -> Union[LineFragment, LiteralFragment]: ...
     def dump(self) -> bytes:
         """
         Dump the (remaining) encoded data without being guided by fragments.

--- a/bindings/imap-codec-python/src/encoded.rs
+++ b/bindings/imap-codec-python/src/encoded.rs
@@ -1,5 +1,109 @@
-use imap_codec::encode::Encoded;
+use imap_codec::{
+    encode::{Encoded, Fragment},
+    imap_types::core::LiteralMode,
+};
 use pyo3::{prelude::*, types::PyBytes};
+
+/// Python class representing a literal mode
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[pyclass(name = "LiteralMode", eq)]
+pub(crate) enum PyLiteralMode {
+    Sync,
+    NonSync,
+}
+
+impl std::fmt::Display for PyLiteralMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PyLiteralMode::Sync => f.write_str("LiteralMode.Sync"),
+            PyLiteralMode::NonSync => f.write_str("LiteralMode.NonSync"),
+        }
+    }
+}
+
+impl From<LiteralMode> for PyLiteralMode {
+    fn from(value: LiteralMode) -> Self {
+        match value {
+            LiteralMode::Sync => PyLiteralMode::Sync,
+            LiteralMode::NonSync => PyLiteralMode::NonSync,
+        }
+    }
+}
+
+/// Python class representing a line fragment
+#[derive(Debug, Clone, PartialEq)]
+#[pyclass(name = "LineFragment", eq)]
+pub(crate) struct PyLineFragment {
+    data: Vec<u8>,
+}
+
+#[pymethods]
+impl PyLineFragment {
+    /// Create a new line fragment from data
+    ///
+    /// `data` can be anything that can be extracted to `Vec`, e.g. Python `bytes`
+    #[new]
+    pub(crate) fn new(data: Vec<u8>) -> Self {
+        Self { data }
+    }
+
+    /// Retrieve the data from the fragment as Python `bytes`
+    #[getter]
+    pub(crate) fn data<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        PyBytes::new_bound(py, self.data.as_slice())
+    }
+
+    /// String representation of the fragment, e.g. `b'hello'`
+    pub(crate) fn __str__(&self, py: Python) -> String {
+        self.data(py).to_string()
+    }
+
+    /// Printable representation of the fragment, e.g. `LineFragment(b'hello')`
+    pub(crate) fn __repr__(&self, py: Python) -> String {
+        format!("LineFragment({})", self.__str__(py))
+    }
+}
+
+/// Python class representing a literal fragment
+#[derive(Debug, Clone, PartialEq)]
+#[pyclass(name = "LiteralFragment", eq)]
+pub(crate) struct PyLiteralFragment {
+    data: Vec<u8>,
+    mode: PyLiteralMode,
+}
+
+#[pymethods]
+impl PyLiteralFragment {
+    /// Create a new literal fragment from data and mode
+    ///
+    /// `data` can be anything that can be extracted to `Vec`, e.g. Python `bytes`
+    #[new]
+    pub(crate) fn try_new(data: Vec<u8>, mode: PyLiteralMode) -> PyResult<Self> {
+        Ok(Self { data, mode })
+    }
+
+    /// Retrieve the data of the fragment as Python `bytes`
+    #[getter]
+    pub(crate) fn data<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        PyBytes::new_bound(py, self.data.as_slice())
+    }
+
+    /// Retrieve the mode of the fragment
+    #[getter]
+    pub(crate) fn mode(&self) -> PyLiteralMode {
+        self.mode
+    }
+
+    /// String representation of the fragment, e.g. `(b'hello', 'Sync')`
+    pub(crate) fn __str__(&self, py: Python) -> String {
+        format!("({}, {})", self.data(py), self.mode)
+    }
+
+    /// Printable representation of the fragment, e.g. `LiteralFragment(b'hello', 'Sync')`
+    pub(crate) fn __repr__(&self, py: Python) -> String {
+        format!("LiteralFragment{}", self.__str__(py))
+    }
+}
 
 /// Python wrapper classes for `Encoded`
 ///
@@ -16,14 +120,22 @@ impl PyEncoded {
     }
 
     /// Return next fragment
-    pub(crate) fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<Bound<PyAny>>> {
-        let Some(encoded) = &mut slf.0 else {
+    pub(crate) fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<PyObject>> {
+        // Try to get next `Fragment` from `Encoded` iterator
+        let Some(fragment) = slf.0.as_mut().and_then(|encoded| encoded.next()) else {
             return Ok(None);
         };
-        Ok(encoded
-            .next()
-            .map(|value| serde_pyobject::to_pyobject(slf.py(), &value))
-            .transpose()?)
+
+        // Return instance of `PyLineFragment` or `PyLiteralFragment` as a generic `PyObject`.
+        Ok(Some(match fragment {
+            Fragment::Line { data } => {
+                Bound::new(slf.py(), PyLineFragment::new(data))?.to_object(slf.py())
+            }
+            Fragment::Literal { data, mode } => {
+                Bound::new(slf.py(), PyLiteralFragment::try_new(data, mode.into())?)?
+                    .to_object(slf.py())
+            }
+        }))
     }
 
     /// Dump remaining fragment data

--- a/bindings/imap-codec-python/src/encoded.rs
+++ b/bindings/imap-codec-python/src/encoded.rs
@@ -1,0 +1,38 @@
+use imap_codec::encode::Encoded;
+use pyo3::{prelude::*, types::PyBytes};
+
+/// Python wrapper classes for `Encoded`
+///
+/// This implements a Python iterator over the containing fragments.
+#[derive(Debug, Clone)]
+#[pyclass(name = "Encoded")]
+pub(crate) struct PyEncoded(pub(crate) Option<Encoded>);
+
+#[pymethods]
+impl PyEncoded {
+    /// Initialize iterator
+    pub(crate) fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// Return next fragment
+    pub(crate) fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<Bound<PyAny>>> {
+        let Some(encoded) = &mut slf.0 else {
+            return Ok(None);
+        };
+        Ok(encoded
+            .next()
+            .map(|value| serde_pyobject::to_pyobject(slf.py(), &value))
+            .transpose()?)
+    }
+
+    /// Dump remaining fragment data
+    pub(crate) fn dump(mut slf: PyRefMut<'_, Self>) -> PyResult<Bound<PyBytes>> {
+        let encoded = slf.0.take();
+        let dump = match encoded {
+            Some(encoded) => encoded.dump(),
+            None => Vec::new(),
+        };
+        Ok(PyBytes::new_bound(slf.py(), &dump))
+    }
+}

--- a/bindings/imap-codec-python/src/lib.rs
+++ b/bindings/imap-codec-python/src/lib.rs
@@ -200,6 +200,9 @@ fn imap_codec_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
         "DecodeLiteralFound",
         m.py().get_type_bound::<DecodeLiteralFound>(),
     )?;
+    m.add_class::<encoded::PyLiteralMode>()?;
+    m.add_class::<encoded::PyLineFragment>()?;
+    m.add_class::<encoded::PyLiteralFragment>()?;
     m.add_class::<PyEncoded>()?;
     m.add_class::<PyGreetingCodec>()?;
     m.add_class::<PyCommandCodec>()?;

--- a/bindings/imap-codec-python/src/lib.rs
+++ b/bindings/imap-codec-python/src/lib.rs
@@ -47,10 +47,10 @@ impl PyEncoded {
     }
 }
 
-/// Wrapper for `GreetingCodec`
+/// Python class for using `GreetingCodec`
 #[derive(Debug, Clone, PartialEq)]
 #[pyclass(name = "GreetingCodec")]
-struct PyGreetingCodec(GreetingCodec);
+struct PyGreetingCodec;
 
 #[pymethods]
 impl PyGreetingCodec {
@@ -80,10 +80,10 @@ impl PyGreetingCodec {
     }
 }
 
-/// Wrapper for `CommandCodec`
+/// Python class for using `CommandCodec`
 #[derive(Debug, Clone, PartialEq)]
 #[pyclass(name = "CommandCodec")]
-struct PyCommandCodec(CommandCodec);
+struct PyCommandCodec;
 
 #[pymethods]
 impl PyCommandCodec {
@@ -119,10 +119,10 @@ impl PyCommandCodec {
     }
 }
 
-/// Wrapper for `AuthenticateDataCodec`
+/// Python class for using `AuthenticateDataCodec`
 #[derive(Debug, Clone, PartialEq)]
 #[pyclass(name = "AuthenticateDataCodec")]
-struct PyAuthenticateDataCodec(AuthenticateDataCodec);
+struct PyAuthenticateDataCodec;
 
 #[pymethods]
 impl PyAuthenticateDataCodec {
@@ -151,10 +151,10 @@ impl PyAuthenticateDataCodec {
     }
 }
 
-/// Wrapper for `ResponseCodec`
+/// Python class for using `ResponseCodec`
 #[derive(Debug, Clone, PartialEq)]
 #[pyclass(name = "ResponseCodec")]
-struct PyResponseCodec(ResponseCodec);
+struct PyResponseCodec;
 
 #[pymethods]
 impl PyResponseCodec {
@@ -188,10 +188,10 @@ impl PyResponseCodec {
     }
 }
 
-/// Wrapper for `IdleDoneCodec`
+/// Python class for using `IdleDoneCodec`
 #[derive(Debug, Clone, PartialEq)]
 #[pyclass(name = "IdleDoneCodec")]
-struct PyIdleDoneCodec(IdleDoneCodec);
+struct PyIdleDoneCodec;
 
 #[pymethods]
 impl PyIdleDoneCodec {

--- a/bindings/imap-codec-python/src/lib.rs
+++ b/bindings/imap-codec-python/src/lib.rs
@@ -1,6 +1,9 @@
+mod encoded;
+
+use encoded::PyEncoded;
 use imap_codec::{
     decode::{self, Decoder},
-    encode::{Encoded, Encoder},
+    encode::Encoder,
     AuthenticateDataCodec, CommandCodec, GreetingCodec, IdleDoneCodec, ResponseCodec,
 };
 use pyo3::{create_exception, exceptions::PyException, prelude::*, types::PyBytes};
@@ -10,42 +13,6 @@ create_exception!(imap_codec, DecodeError, PyException);
 create_exception!(imap_codec, DecodeFailed, DecodeError);
 create_exception!(imap_codec, DecodeIncomplete, DecodeError);
 create_exception!(imap_codec, DecodeLiteralFound, DecodeError);
-
-/// Wrapper for `Encoded`
-///
-/// This implements a Python iterator over the containing fragments.
-#[derive(Debug, Clone)]
-#[pyclass(name = "Encoded")]
-struct PyEncoded(Option<Encoded>);
-
-#[pymethods]
-impl PyEncoded {
-    /// Initialize iterator
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
-        slf
-    }
-
-    /// Return next fragment
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<Bound<PyAny>>> {
-        let Some(encoded) = &mut slf.0 else {
-            return Ok(None);
-        };
-        Ok(encoded
-            .next()
-            .map(|value| serde_pyobject::to_pyobject(slf.py(), &value))
-            .transpose()?)
-    }
-
-    /// Dump remaining fragment data
-    fn dump(mut slf: PyRefMut<'_, Self>) -> PyResult<Bound<PyBytes>> {
-        let encoded = slf.0.take();
-        let dump = match encoded {
-            Some(encoded) => encoded.dump(),
-            None => Vec::new(),
-        };
-        Ok(PyBytes::new_bound(slf.py(), &dump))
-    }
-}
 
 /// Python class for using `GreetingCodec`
 #[derive(Debug, Clone, PartialEq)]

--- a/bindings/imap-codec-python/tests/test_authenticate_data_encode.py
+++ b/bindings/imap-codec-python/tests/test_authenticate_data_encode.py
@@ -1,6 +1,6 @@
 import unittest
 
-from imap_codec import AuthenticateDataCodec, Encoded
+from imap_codec import AuthenticateDataCodec, Encoded, LineFragment
 
 
 class TestAuthenticateDataEncode(unittest.TestCase):
@@ -9,7 +9,7 @@ class TestAuthenticateDataEncode(unittest.TestCase):
         encoded = AuthenticateDataCodec.encode(authenticate_data)
         self.assertIsInstance(encoded, Encoded)
         fragments = list(encoded)
-        self.assertEqual(fragments, [{"Line": {"data": list(b"VGVzdA==\r\n")}}])
+        self.assertEqual(fragments, [LineFragment(b"VGVzdA==\r\n")])
 
     def test_authenticate_data_dump(self):
         authenticate_data = {"Continue": list(b"Test")}

--- a/bindings/imap-codec-python/tests/test_fragments.py
+++ b/bindings/imap-codec-python/tests/test_fragments.py
@@ -1,0 +1,101 @@
+import unittest
+
+from imap_codec import LineFragment, LiteralFragment, LiteralMode
+
+
+class TestLineFragment(unittest.TestCase):
+    def test_data(self):
+        data = b"a NOOP\r\n"
+        fragment = LineFragment(data)
+        self.assertEqual(fragment.data, data)
+
+    def test_repr(self):
+        data = b"a NOOP\r\n"
+        fragment = LineFragment(data)
+        self.assertEqual(repr(fragment), f"LineFragment({data})")
+
+    def test_str(self):
+        data = b"a NOOP\r\n"
+        fragment = LineFragment(data)
+        self.assertEqual(str(fragment), str(data))
+
+    def test_eq(self):
+        fragment1 = LineFragment(b"a NOOP\r\n")
+        fragment2 = LineFragment(b"a NOOP\r\n")
+        fragment3 = LineFragment(b"a LOGIN alice pass\r\n")
+
+        self.assertEqual(fragment1, fragment1)
+        self.assertEqual(fragment1, fragment2)
+        self.assertNotEqual(fragment1, fragment3)
+
+        self.assertEqual(fragment2, fragment1)
+        self.assertEqual(fragment2, fragment2)
+        self.assertNotEqual(fragment2, fragment3)
+
+        self.assertNotEqual(fragment3, fragment1)
+        self.assertNotEqual(fragment3, fragment2)
+        self.assertEqual(fragment3, fragment3)
+
+
+class TestLiteralFragment(unittest.TestCase):
+    def test_data(self):
+        data = b"\x01\x02\x03\x04"
+        fragment = LiteralFragment(data, LiteralMode.Sync)
+        self.assertEqual(fragment.data, data)
+
+    def test_mode(self):
+        mode = LiteralMode.Sync
+        fragment = LiteralFragment(b"\x01\x02\x03\x04", mode)
+        self.assertEqual(fragment.mode, mode)
+
+        mode = LiteralMode.NonSync
+        fragment = LiteralFragment(b"\x01\x02\x03\x04", mode)
+        self.assertEqual(fragment.mode, mode)
+
+    def test_repr(self):
+        data = b"\x01\x02\x03\x04"
+
+        mode = LiteralMode.Sync
+        fragment = LiteralFragment(data, mode)
+        self.assertEqual(repr(fragment), f"LiteralFragment({data}, {mode})")
+
+        mode = LiteralMode.NonSync
+        fragment = LiteralFragment(data, mode)
+        self.assertEqual(repr(fragment), f"LiteralFragment({data}, {mode})")
+
+    def test_str(self):
+        data = b"\x01\x02\x03\x04"
+
+        mode = LiteralMode.Sync
+        fragment = LiteralFragment(data, mode)
+        self.assertEqual(str(fragment), f"({data}, {mode})")
+
+        mode = LiteralMode.NonSync
+        fragment = LiteralFragment(data, mode)
+        self.assertEqual(str(fragment), f"({data}, {mode})")
+
+    def test_eq(self):
+        fragment1 = LiteralFragment(b"data", LiteralMode.Sync)
+        fragment2 = LiteralFragment(b"data", LiteralMode.Sync)
+        fragment3 = LiteralFragment(b"data", LiteralMode.NonSync)
+        fragment4 = LiteralFragment(b"\x01\x02\x03\x04", LiteralMode.NonSync)
+
+        self.assertEqual(fragment1, fragment1)
+        self.assertEqual(fragment1, fragment2)
+        self.assertNotEqual(fragment1, fragment3)
+        self.assertNotEqual(fragment1, fragment4)
+
+        self.assertEqual(fragment2, fragment1)
+        self.assertEqual(fragment2, fragment2)
+        self.assertNotEqual(fragment2, fragment3)
+        self.assertNotEqual(fragment2, fragment4)
+
+        self.assertNotEqual(fragment3, fragment1)
+        self.assertNotEqual(fragment3, fragment2)
+        self.assertEqual(fragment3, fragment3)
+        self.assertNotEqual(fragment3, fragment4)
+
+        self.assertNotEqual(fragment4, fragment1)
+        self.assertNotEqual(fragment4, fragment2)
+        self.assertNotEqual(fragment4, fragment3)
+        self.assertEqual(fragment4, fragment4)

--- a/bindings/imap-codec-python/tests/test_greeting_encode.py
+++ b/bindings/imap-codec-python/tests/test_greeting_encode.py
@@ -1,6 +1,6 @@
 import unittest
 
-from imap_codec import Encoded, GreetingCodec
+from imap_codec import Encoded, GreetingCodec, LineFragment
 
 
 class TestGreetingEncode(unittest.TestCase):
@@ -9,9 +9,7 @@ class TestGreetingEncode(unittest.TestCase):
         encoded = GreetingCodec.encode(greeting)
         self.assertIsInstance(encoded, Encoded)
         fragments = list(encoded)
-        self.assertEqual(
-            fragments, [{"Line": {"data": list(b"* OK Hello, World!\r\n")}}]
-        )
+        self.assertEqual(fragments, [LineFragment(b"* OK Hello, World!\r\n")])
 
     def test_simple_greeting_dump(self):
         greeting = {"code": None, "kind": "Ok", "text": "Hello, World!"}

--- a/bindings/imap-codec-python/tests/test_idle_done_encode.py
+++ b/bindings/imap-codec-python/tests/test_idle_done_encode.py
@@ -1,6 +1,6 @@
 import unittest
 
-from imap_codec import Encoded, IdleDoneCodec
+from imap_codec import Encoded, IdleDoneCodec, LineFragment
 
 
 class TestIdleDoneEncode(unittest.TestCase):
@@ -9,7 +9,7 @@ class TestIdleDoneEncode(unittest.TestCase):
         encoded = IdleDoneCodec.encode(idle_done)
         self.assertIsInstance(encoded, Encoded)
         fragments = list(encoded)
-        self.assertEqual(fragments, [{"Line": {"data": list(b"DONE\r\n")}}])
+        self.assertEqual(fragments, [LineFragment(b"DONE\r\n")])
 
     def test_idle_done_dump(self):
         idle_done = ()


### PR DESCRIPTION
This replaces the dictionaries returned by the `Encoded` iterator with individual `LineFragement` and `LiteralFragment` classes that can be handled more intuitively from the Python code.

Closes #560.