### PR TITLE
Remove serialization of `Fragment`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,8 +1206,6 @@ dependencies = [
  "imap-types",
  "log",
  "nom",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -18,7 +18,7 @@ default = ["quirk"]
 fuzz = []
 
 # <Forward to imap-types>
-serde = ["dep:serde", "imap-types/serde"]
+serde = ["imap-types/serde"]
 
 # IMAP
 starttls = ["imap-types/starttls"]
@@ -69,10 +69,6 @@ chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 imap-types = { version = "2.0.0-alpha.3", path = "../imap-types", default-features = false }
 nom = { version = "7", default-features = false }
 log = { version = "0.4.22", default-features = false }
-serde = { version = "1.0.203", features = ["derive"], optional = true }
-
-[dev-dependencies]
-serde_json = { version = "1.0.119" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/imap-codec/src/codec/encode.rs
+++ b/imap-codec/src/codec/encode.rs
@@ -77,8 +77,6 @@ use imap_types::{
     status::{StatusDataItem, StatusDataItemName},
     utils::escape_quoted,
 };
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 use utils::{join_serializable, List1AttributeValueOrNil, List1OrNil};
 
 use crate::{AuthenticateDataCodec, CommandCodec, GreetingCodec, IdleDoneCodec, ResponseCodec};
@@ -150,7 +148,6 @@ impl Iterator for Encoded {
 }
 
 /// The intended action of a client or server.
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Fragment {
     /// A line that is ready to be send.
@@ -2112,32 +2109,5 @@ mod tests {
 
             assert_eq!(encoder.collect::<Vec<_>>(), actions);
         }
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn test_serialize_fragment() {
-        let fragments = [
-            Fragment::Line {
-                data: b"A LOGIN alice {2}\r\n".to_vec(),
-            },
-            Fragment::Literal {
-                data: b"\xCA\xFE".to_vec(),
-                mode: LiteralMode::Sync,
-            },
-            Fragment::Line {
-                data: b"\r\n".to_vec(),
-            },
-        ];
-
-        let json = serde_json::to_string(&fragments).unwrap();
-        assert_eq!(
-            json,
-            r#"[{"Line":{"data":[65,32,76,79,71,73,78,32,97,108,105,99,101,32,123,50,125,13,10]}},{"Literal":{"data":[202,254],"mode":"Sync"}},{"Line":{"data":[13,10]}}]"#
-        );
-        assert_eq!(
-            serde_json::from_str::<[Fragment; 3]>(&json).unwrap(),
-            fragments
-        );
     }
 }


### PR DESCRIPTION
Since #561, the encoded fragments are no longer deserialized into Python objects. Thus `Fragment` no longer has to implement `Serialize`.

For version 2.0, we are not aiming for implementing `Serialize`/`Deserialize` for types in `imap-codec` (see #555). Thus, removing the single implementation restores consistency for the release.