### PR TITLE
chore: Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "imap-codec"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "abnf-core",
  "base64 0.22.1",


### PR DESCRIPTION
The updated `Cargo.lock` was not added to version control when the
version number for `imap-codec` was previously bumped.