### PR TITLE
build: Remove CI path filters

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,18 +2,8 @@ name: audit
 on:
   push:
     branches: [ main ]
-    paths:
-      - "**.rs"
-      - "**.toml"
-      - ".github/workflows/**"
-      - "justfile"
   pull_request:
     branches: [ main ]
-    paths:
-      - "**.rs"
-      - "**.toml"
-      - ".github/workflows/**"
-      - "justfile"
   schedule:
     # 21:43 on Wednesday and Sunday. (Thanks, crontab.guru)
     - cron: '43 21 * * 3,0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,18 +2,8 @@ name: main
 on:
   push:
     branches: [ main ]
-    paths:
-      - "**.rs"
-      - "**.toml"
-      - ".github/workflows/**"
-      - "justfile"
   pull_request:
     branches: [ main ]
-    paths:
-      - "**.rs"
-      - "**.toml"
-      - ".github/workflows/**"
-      - "justfile"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
As some CI jobs are required for PRs to be merged, these jobs have to be run even if only non-source file would be modified. Thus, the path filters for PR runs have to be removed.
Additionally, correctly managing the path lists turns out to be very error prone. Thus, removing them for the `main` branch seems to make more sense than keeping and managing them there.