### PR TITLE
chore: Obey new Clippy lint

### DIFF
--- a/imap-codec/src/sequence.rs
+++ b/imap-codec/src/sequence.rs
@@ -66,7 +66,7 @@ pub(crate) fn seq_range(input: &[u8]) -> IMAPResult<&[u8], (SeqOrUid, SeqOrUid)>
 /// Message sequence number (COPY, FETCH, STORE commands) or unique
 /// identifier (UID COPY, UID FETCH, UID STORE commands).
 ///
-/// * represents the largest number in use.
+/// "*" represents the largest number in use.
 /// In the case of message sequence numbers, it is the number of messages in a non-empty mailbox.
 /// In the case of unique identifiers, it is the unique identifier of the last message in the mailbox or,
 /// if the mailbox is empty, the mailbox's current UIDNEXT value.

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -701,8 +701,9 @@ impl<'a> CommandContinuationRequestBasic<'a> {
     /// Create a basic continuation request.
     ///
     /// Note: To avoid ambiguities in the IMAP standard, this constructor ensures that:
-    /// * iff `code` is `None`, `text` must not start with `[`.
-    /// * iff `code` is `None`, `text` must *not* be valid according to base64.
+    /// * if `code` is `None`, `text` must not start with `[`.
+    /// * if `code` is `None`, `text` must *not* be valid according to base64.
+    ///
     /// Otherwise, we could send a `Continue::Basic` that is interpreted as `Continue::Base64`.
     pub fn new<T>(code: Option<Code<'a>>, text: T) -> Result<Self, ContinueError<T::Error>>
     where


### PR DESCRIPTION
Clippy 1.80.0 (2024-07-21) introduced a new lint [`doc_lazy_continuation`](https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation) that was triggered by some of the existing doc comments. This fixes these comments.