### PR TITLE
build: Add metadata for Python bindings

### DIFF
--- a/bindings/imap-codec-python/Cargo.toml
+++ b/bindings/imap-codec-python/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "imap-codec-python"
-description = "Python bindings for imap-codec"
+description = "Python bindings for imap-codec Rust crate"
+keywords = ["email", "imap", "codec", "parser"]
 version = "0.1.0-dev1"
+authors = [
+    "Damian Poddebniak <poddebniak@mailbox.org>",
+    "Henning Holm <git@henningholm.de>",
+]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 publish = false

--- a/bindings/imap-codec-python/pyproject.toml
+++ b/bindings/imap-codec-python/pyproject.toml
@@ -6,10 +6,24 @@ build-backend = "maturin"
 name = "imap-codec"
 requires-python = ">=3.8"
 classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Communications :: Email :: Post-Office :: IMAP",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
 ]
 dynamic = ["version"]
+
+[project.urls]
+source = "https://github.com/duesee/imap-codec"
+tracker = "https://github.com/duesee/imap-codec/issues"
+
 [tool.maturin]
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
This populates several metadata fields for the Python bindings that will be used by PyPI for the package.
As maturin merges metadata from `Cargo.toml` and `pyproject.toml` into the package (with higher precedence on `pyproject.toml`), compatible metadata was added to `Cargo.toml`.

This closes #557.