### PR TITLE
Add CI workflow for publishing Rust crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'imap-codec/v*'
+      - 'imap-types/v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract crate name from Git tag
+        run: |
+          set -euo pipefail
+          tag_name=${GITHUB_REF#refs/tags/}
+          crate_name=${tag_name%/v*}
+          echo "Extracted crate name: $crate_name"
+          echo "CRATE_NAME=$crate_name" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+
+      - name: Assert release version matches crate version
+        run: |
+          set -euo pipefail
+  
+          # Get release version from Git tag
+          tag_version=${GITHUB_REF#refs/tags/$CRATE_NAME/v}
+  
+          # Get crate version from Cargo.toml
+          cd $CRATE_NAME
+          crate_version=$(cargo read-manifest | jq -r .version)
+            
+          if [ "$tag_version" != "$crate_version" ]; then
+            echo "Error: Release version in Git tag (${tag_version}) does not match crate version in Cargo.toml (${crate_version}) for crate $CRATE_NAME."
+            exit 1
+          fi
+
+      - name: Publish crate to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p $CRATE_NAME

--- a/assets/demos/tokio-client/Cargo.toml
+++ b/assets/demos/tokio-client/Cargo.toml
@@ -3,6 +3,7 @@ name = "tokio-client"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/assets/demos/tokio-server/Cargo.toml
+++ b/assets/demos/tokio-server/Cargo.toml
@@ -3,6 +3,7 @@ name = "tokio-server"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/assets/demos/tokio-support/Cargo.toml
+++ b/assets/demos/tokio-support/Cargo.toml
@@ -3,6 +3,7 @@ name = "tokio-support"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This adds a basic CI workflow for automatically publishing the Rust crates (currently `imap-codec` and `imap-types`) to crates.io when a corresponding Git tag is pushed.
For now, only the tag's version number is checked against the version number specified in the crates `Cargo.toml` file before publishing the crate is performed.

Later on, the release workflow could be further automated using crated like [`cargo-workspaces`](https://github.com/pksunkara/cargo-workspaces), [`cargo-release`](https://github.com/crate-ci/cargo-release) or [`cargo-smart-release`](https://github.com/Byron/cargo-smart-release). However, for that, a formal release workflow (when to release, which version number to bump which way and so on) has to be decided on first.