### PR TITLE
chore: Bump Python bindings version to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "imap-codec-python"
-version = "0.1.0-dev1"
+version = "0.1.0"
 dependencies = [
  "imap-codec",
  "pyo3",

--- a/bindings/imap-codec-python/Cargo.toml
+++ b/bindings/imap-codec-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "imap-codec-python"
 description = "Python bindings for imap-codec Rust crate"
 keywords = ["email", "imap", "codec", "parser"]
-version = "0.1.0-dev1"
+version = "0.1.0"
 authors = [
     "Damian Poddebniak <poddebniak@mailbox.org>",
     "Henning Holm <git@henningholm.de>",


### PR DESCRIPTION
As the initial development pre-release seems to have worked as intended, we can now perform an actual release.

The package can successfully be installed from PyPI using pip:
```
> python -m pip install imap-codec
Collecting imap-codec
  Downloading imap_codec-0.1.0.dev1-cp312-none-win_amd64.whl.metadata (2.7 kB)
Downloading imap_codec-0.1.0.dev1-cp312-none-win_amd64.whl (898 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 898.3/898.3 kB 3.6 MB/s eta 0:00:00
Installing collected packages: imap-codec
Successfully installed imap-codec-0.1.0.dev1

> python -m unittest                     
..............................................................
----------------------------------------------------------------------
Ran 62 tests in 0.007s

OK
```