### PR TITLE
build: fix flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
           # `rust-toolchain.toml` configuration file
           rust-toolchain = fenix.packages.${system}.fromToolchainFile {
             file = ./rust-toolchain.toml;
-            sha256 = "opUgs6ckUQCyDxcB9Wy51pqhd0MPGHUVbwRKKPGiwZU=";
+            sha256 = "X/4ZBHO3iW0fOenQ3foEvscgAPJYl2abspaBThDOukI=";
           };
 
         in


### PR DESCRIPTION
```sh
$ nix develop
```

... lead to ...

```
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/p648p3av68k4h6li0126ddkznmr1mj2s-source/pkgs/stdenv/generic/make-derivation.nix:348:7

       … while evaluating attribute 'buildInputs' of derivation 'nix-shell'
         at /nix/store/p648p3av68k4h6li0126ddkznmr1mj2s-source/pkgs/stdenv/generic/make-derivation.nix:395:7:
          394|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          395|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          396|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: hash mismatch in fixed-output derivation '/nix/store/p2agx9dsvcdgfniwnanb8chhjnn2hhv9-channel-rust-stable.toml.drv':
         specified: sha256-opUgs6ckUQCyDxcB9Wy51pqhd0MPGHUVbwRKKPGiwZU=
            got:    sha256-X/4ZBHO3iW0fOenQ3foEvscgAPJYl2abspaBThDOukI=
```

This PR (seemingly) resolves the issue. However... from my understanding, this should not have been required? Did this ever work? Does the hash have something to do with `rust-toolchain.toml`? Still learning Nix... Any advice, @soywod?