### PR TITLE
refactor: Rename `quirk_trailing_space` to `quirk_trailing_space_status`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "imap-types",
     "imap-types/fuzz",
 ]
+
+[workspace.package]
+rust-version = "1.85"

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,6 @@
           default = pkgs.mkShell {
             strictDeps = true;
             nativeBuildInputs = with pkgs; [
-              jq
               just
               rustPlatform.bindgenHook
               rustup

--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -7,7 +7,7 @@ version = "2.0.0-alpha.5"
 authors = ["Damian Poddebniak <poddebniak@mailbox.org>"]
 repository = "https://github.com/duesee/imap-codec"
 license = "MIT OR Apache-2.0"
-rust-version = "1.85"
+rust-version.workspace = true
 edition = "2024"
 exclude = [
     ".github",

--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -28,7 +28,7 @@ quirk = [
     "quirk_missing_text",
     "quirk_rectify_numbers",
     "quirk_excessive_space_quota_resource",
-    "quirk_trailing_space", # TODO(#653): Rename to "_status".
+    "quirk_trailing_space_status",
     "quirk_trailing_space_capability",
     "quirk_trailing_space_id",
     "quirk_trailing_space_search",
@@ -49,7 +49,7 @@ quirk_excessive_space_quota_resource = []
 # Accept spaces between envelope addresses in `FETCH` data response.
 quirk_spaces_between_addresses = []
 # Accept a trailing space in `STATUS` data response.
-quirk_trailing_space = []
+quirk_trailing_space_status = []
 # Accept a trailing space in `CAPABILITY` data response.
 quirk_trailing_space_capability = []
 # Accept a trailing space in `ID` data response.

--- a/imap-codec/src/mailbox.rs
+++ b/imap-codec/src/mailbox.rs
@@ -156,9 +156,9 @@ pub(crate) fn mailbox_data(input: &[u8]) -> IMAPResult<&[u8], Data> {
                 tag_no_case(b"STATUS "),
                 mailbox,
                 delimited(tag(b" ("), opt(status_att_list), tag(b")")),
-                #[cfg(feature = "quirk_trailing_space")]
+                #[cfg(feature = "quirk_trailing_space_status")]
                 opt(sp),
-                #[cfg(not(feature = "quirk_trailing_space"))]
+                #[cfg(not(feature = "quirk_trailing_space_status"))]
                 nom::combinator::success(()),
             )),
             |(_, mailbox, items, _)| Data::Status {

--- a/imap-codec/src/response.rs
+++ b/imap-codec/src/response.rs
@@ -792,10 +792,10 @@ mod tests {
         assert!(response_data(b"* STATUS INBOX (MESSAGES 100 UNSEEN 0)\r\n").is_ok());
         assert!(response_data(b"* STATUS INBOX (MESSAGES 100 UNSEEN 0)  \r\n").is_err());
 
-        #[cfg(not(feature = "quirk_trailing_space"))]
+        #[cfg(not(feature = "quirk_trailing_space_status"))]
         assert!(response_data(b"* STATUS INBOX (MESSAGES 100 UNSEEN 0) \r\n").is_err());
 
-        #[cfg(feature = "quirk_trailing_space")]
+        #[cfg(feature = "quirk_trailing_space_status")]
         assert!(response_data(b"* STATUS INBOX (MESSAGES 100 UNSEEN 0) \r\n").is_ok());
     }
 

--- a/imap-types/Cargo.toml
+++ b/imap-types/Cargo.toml
@@ -7,7 +7,7 @@ version = "2.0.0-alpha.4"
 authors = ["Damian Poddebniak <poddebniak@mailbox.org>"]
 repository = "https://github.com/duesee/imap-codec"
 license = "MIT OR Apache-2.0"
-rust-version = "1.85"
+rust-version.workspace = true
 edition = "2024"
 exclude = [
     ".github",

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 export RUSTFLAGS := "-D warnings"
 export RUSTDOCFLAGS := "-D warnings"
 
-msrv := `cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "imap-codec") | .rust_version'`
+msrv := `sed -rn 's|^rust-version = \"(.*)\"$|\1|p' Cargo.toml`
 
 [private]
 default:

--- a/justfile
+++ b/justfile
@@ -64,10 +64,10 @@ cargo_hack mode: install_cargo_hack
         quirk_missing_text,\
         quirk_rectify_numbers,\
         quirk_excessive_space_quota_resource,\
-        quirk_trailing_space,\
         quirk_trailing_space_capability,\
         quirk_trailing_space_id,\
         quirk_trailing_space_search,\
+        quirk_trailing_space_status,\
         quirk_spaces_between_addresses,\
         quirk_empty_continue_req,\
         quirk_body_fld_enc_nil_to_empty\


### PR DESCRIPTION
Plus small refactor of msrv handling (thanks @jakoschiko).