### PR TITLE
Adjacently tagged enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Check only explicit features for SemVer violations
 * Renamed `NonEmptyVec` to `Vec1`
 * Updated `CONTRIBUTING.md`
+* Changed serde representation for many `enum`s from externally to adjacently tagged
 
 ### Fixed
 

--- a/imap-types/src/auth.rs
+++ b/imap-types/src/auth.rs
@@ -20,6 +20,7 @@ use crate::{
 
 /// Authentication mechanism.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum AuthMechanism<'a> {
@@ -205,6 +206,7 @@ pub struct AuthMechanismOther<'a>(Atom<'a>);
 /// Holds the raw binary data, i.e., a `Vec<u8>`, *not* the BASE64 string.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum AuthenticateData<'a> {
     /// Continue SASL authentication.

--- a/imap-types/src/body.rs
+++ b/imap-types/src/body.rs
@@ -49,6 +49,7 @@ pub struct BasicFields<'a> {
 /// Specific fields of a non-multipart body part.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum SpecificFields<'a> {
     /// # Example (not in RFC)
@@ -166,6 +167,7 @@ pub enum SpecificFields<'a> {
 
 /// The BODY(STRUCTURE).
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum BodyStructure<'a> {
     /// For example, a simple text message of 48 lines and 2279 octets
@@ -326,6 +328,7 @@ pub struct Location<'a> {
 
 /// Helper to enforce correct usage of [`SinglePartExtensionData`] and [`MultiPartExtensionData`].
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum BodyExtension<'a> {
     /// NString.

--- a/imap-types/src/command.rs
+++ b/imap-types/src/command.rs
@@ -70,6 +70,7 @@ impl<'a> Command<'a> {
 /// This enum is used to encode all the different commands.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum CommandBody<'a> {
     // ----- Any State (see https://tools.ietf.org/html/rfc3501#section-6.1) -----
@@ -1847,6 +1848,7 @@ impl<'a> CommandBody<'a> {
 #[cfg_attr(docsrs, doc(cfg("ext_condstore_qresync")))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum SelectParameter {
     CondStore,
@@ -1862,6 +1864,7 @@ pub enum SelectParameter {
 #[cfg_attr(docsrs, doc(cfg("ext_condstore_qresync")))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum FetchModifier {
     ChangedSince(NonZeroU64),
@@ -1872,6 +1875,7 @@ pub enum FetchModifier {
 #[cfg_attr(docsrs, doc(cfg("ext_condstore_qresync")))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum StoreModifier {
     UnchangedSince(u64),

--- a/imap-types/src/core.rs
+++ b/imap-types/src/core.rs
@@ -388,6 +388,7 @@ impl AsRef<str> for AtomExt<'_> {
 /// ;        See `Quoted`
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum IString<'a> {
     /// Literal, see [`Literal`].
@@ -939,6 +940,7 @@ impl<'a> From<Quoted<'a>> for NString<'a> {
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum AString<'a> {
     // `1*ATOM-CHAR` does not allow resp-specials, but `1*ASTRING-CHAR` does ... :-/
@@ -1428,6 +1430,7 @@ impl TryFrom<char> for QuotedChar {
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Charset<'a> {
     Atom(Atom<'a>),
@@ -1507,6 +1510,7 @@ impl AsRef<str> for Charset<'_> {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub enum NString8<'a> {
     NString(NString<'a>),

--- a/imap-types/src/extensions/binary.rs
+++ b/imap-types/src/extensions/binary.rs
@@ -16,6 +16,7 @@ use crate::core::{Literal, LiteralMode};
 /// Either a [`Literal`] or [`Literal8`].
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, ToStatic)]
 pub enum LiteralOrLiteral8<'a> {
     Literal(Literal<'a>),

--- a/imap-types/src/extensions/compress.rs
+++ b/imap-types/src/extensions/compress.rs
@@ -35,6 +35,7 @@ impl CommandBody<'_> {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum CompressionAlgorithm {

--- a/imap-types/src/extensions/condstore_qresync.rs
+++ b/imap-types/src/extensions/condstore_qresync.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{core::Atom, error::ValidationError};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum AttributeFlag<'a> {
     Answered,

--- a/imap-types/src/extensions/enable.rs
+++ b/imap-types/src/extensions/enable.rs
@@ -35,6 +35,7 @@ impl<'a> CommandBody<'a> {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum CapabilityEnable<'a> {

--- a/imap-types/src/extensions/metadata.rs
+++ b/imap-types/src/extensions/metadata.rs
@@ -47,6 +47,7 @@ impl AsRef<[u8]> for Entry<'_> {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub enum GetMetadataOption {
     /// Only return values that are less than or equal in octet size to the specified limit.
@@ -75,6 +76,7 @@ pub enum Depth {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub enum MetadataCode {
     LongEntries(u32),
@@ -85,6 +87,7 @@ pub enum MetadataCode {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, ToStatic)]
 pub enum MetadataResponse<'a> {
     WithValues(Vec1<EntryValue<'a>>),

--- a/imap-types/src/extensions/quota.rs
+++ b/imap-types/src/extensions/quota.rs
@@ -123,6 +123,7 @@ impl<'a> Data<'a> {
 ///
 /// Supported resource names MUST be advertised as a capability by prepending the resource name with "QUOTA=RES-".
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Resource<'a> {
     /// The physical space estimate, in units of 1024 octets, of the mailboxes governed by the quota

--- a/imap-types/src/extensions/sort.rs
+++ b/imap-types/src/extensions/sort.rs
@@ -11,6 +11,7 @@ use crate::arbitrary::impl_arbitrary_try_from;
 use crate::core::Atom;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum SortAlgorithm<'a> {
     Display,

--- a/imap-types/src/extensions/thread.rs
+++ b/imap-types/src/extensions/thread.rs
@@ -14,6 +14,7 @@ use crate::arbitrary::impl_arbitrary_try_from;
 use crate::core::{Atom, Vec1, Vec2};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Thread {
     Members {
@@ -136,6 +137,7 @@ fn arbitrary_thread_leaf(u: &mut Unstructured) -> arbitrary::Result<Thread> {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum ThreadingAlgorithm<'a> {
     OrderedSubject,

--- a/imap-types/src/extensions/uidplus.rs
+++ b/imap-types/src/extensions/uidplus.rs
@@ -15,6 +15,7 @@ pub struct UidSet(pub Vec1<UidElement>);
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum UidElement {
     Single(NonZeroU32),

--- a/imap-types/src/extensions/utf8.rs
+++ b/imap-types/src/extensions/utf8.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum Utf8Kind {

--- a/imap-types/src/fetch.rs
+++ b/imap-types/src/fetch.rs
@@ -24,6 +24,7 @@ use crate::{
 /// Shorthands for commonly-used message data items.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum Macro {
@@ -62,6 +63,7 @@ impl Display for Macro {
 /// A macro must be used by itself, and not in conjunction with other macros or data items.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum MacroOrMessageDataItemNames<'a> {
     Macro(Macro),
@@ -83,6 +85,7 @@ impl<'a> From<Vec<MessageDataItemName<'a>>> for MacroOrMessageDataItemNames<'a> 
 /// Message data item name used to request a message data item.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[doc(alias = "FetchAttribute")]
 pub enum MessageDataItemName<'a> {
@@ -246,6 +249,7 @@ pub enum MessageDataItemName<'a> {
 /// Message data item.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[doc(alias = "FetchAttributeValue")]
 pub enum MessageDataItem<'a> {
@@ -429,6 +433,7 @@ pub enum MessageDataItem<'a> {
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Section<'a> {
     Part(Part),
@@ -472,6 +477,7 @@ pub struct Part(pub Vec1<NonZeroU32>);
 /// except in the case of a message which has no body and no blank
 /// line.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum PartSpecifier<'a> {
     PartNumber(u32),

--- a/imap-types/src/flag.rs
+++ b/imap-types/src/flag.rs
@@ -23,6 +23,7 @@ use crate::{core::Atom, error::ValidationError};
 ///
 /// Note that a flag of either type can be permanent or session-only.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Flag<'a> {
     /// Message has been answered (`\Answered`).
@@ -93,6 +94,7 @@ impl Display for Flag<'_> {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum FlagFetch<'a> {
     Flag(Flag<'a>),
@@ -114,6 +116,7 @@ impl<'a> From<Flag<'a>> for FlagFetch<'a> {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum FlagPerm<'a> {
     Flag(Flag<'a>),
@@ -131,6 +134,7 @@ impl<'a> From<Flag<'a>> for FlagPerm<'a> {
 
 /// Four name attributes are defined.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum FlagNameAttribute<'a> {
     /// It is not possible for any child levels of hierarchy to exist

--- a/imap-types/src/mailbox.rs
+++ b/imap-types/src/mailbox.rs
@@ -88,6 +88,7 @@ impl AsRef<[u8]> for ListCharString<'_> {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum ListMailbox<'a> {
     Token(ListCharString<'a>),
@@ -170,6 +171,7 @@ impl TryFrom<String> for ListMailbox<'_> {
 /// 5) Two characters, "#" and "&", have meanings by convention, and should be avoided except
 ///    when used in that convention.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Mailbox<'a> {
     Inbox,
@@ -346,8 +348,8 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialization_mailbox_other() {
-        let valid_input = r#"{ "Atom": "other" }"#;
-        let invalid_input = r#"{ "Atom": "inbox" }"#;
+        let valid_input = r#"{ "type": "Atom", "content": "other" }"#;
+        let invalid_input = r#"{ "type": "Atom", "content": "inbox" }"#;
 
         let mailbox_other = serde_json::from_str::<MailboxOther>(valid_input)
             .expect("valid input should deserialize successfully");

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -114,6 +114,7 @@ pub enum GreetingKind {
 /// Response.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Response<'a> {
     /// Command continuation request responses use the token "+" instead of a
@@ -134,6 +135,7 @@ pub enum Response<'a> {
 
 /// Status response.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Status<'a> {
     Untagged(StatusBody<'a>),
@@ -311,6 +313,7 @@ impl<'a> Status<'a> {
 /// ## 7.2 - 7.4 Server and Mailbox Status; Mailbox Size; Message Status
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Data<'a> {
     // ## 7.2. Server Responses - Server and Mailbox Status
@@ -663,6 +666,7 @@ impl<'a> Data<'a> {
 /// space and those arguments.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[doc(alias = "Continue")]
 #[doc(alias = "Continuation")]
@@ -767,6 +771,7 @@ impl<'a> CommandContinuationRequestBasic<'a> {
 /// The currently defined response codes are:
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Code<'a> {
     /// `ALERT`
@@ -1038,6 +1043,7 @@ impl<'a> CodeOther<'a> {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[non_exhaustive]
 pub enum Capability<'a> {

--- a/imap-types/src/search.rs
+++ b/imap-types/src/search.rs
@@ -14,6 +14,7 @@ use crate::{
 
 /// The defined search keys.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum SearchKey<'a> {
     // <Not in RFC.>

--- a/imap-types/src/sequence.rs
+++ b/imap-types/src/sequence.rs
@@ -125,6 +125,7 @@ impl FromStr for SequenceSet {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 pub enum Sequence {
     Single(SeqOrUid),
@@ -176,6 +177,7 @@ impl FromStr for Sequence {
 
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy, ToStatic)]
 pub enum SeqOrUid {
     Value(NonZeroU32),

--- a/imap-types/src/state.rs
+++ b/imap-types/src/state.rs
@@ -58,6 +58,7 @@ use crate::{core::Tag, mailbox::Mailbox};
 
 /// State of the IMAP4rev1 connection.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Clone, Debug, Eq, PartialEq, ToStatic)]
 pub enum State<'a> {
     Greeting,

--- a/imap-types/src/status.rs
+++ b/imap-types/src/status.rs
@@ -41,6 +41,7 @@ pub enum StatusDataItemName {
 /// Status data item.
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
 #[doc(alias = "StatusAttributeValue")]
 pub enum StatusDataItem {


### PR DESCRIPTION
The current serde representation of enums is externally tagged (the default). It's complicated to work with in Python. We want to use adjacently tagged for most enums. See https://github.com/duesee/imap-codec-python/issues/12.

Basically I added the following line to many enums:

```rust
#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
```

Why did I choose `"type"` and `"content"`?
- `"content"` seems to be a common name, the serde parameter is also called `content`
- I would prefer `"tag"` over `"type"`, but `"tag"` has already an important meaning in IMAP
- I prefer `"type"` over `"kind"` because most people are more familiar with the term type

Simple enums like `enum { Foo, Bar }` are an exception. All variants are already represented by a JSON string, thus they are very convenient to use in Python. A problem might occur if we add a non-simple variant, because we want consistency for all variants of an enum. So I decided to use adjacently tagged for some simple enums that might have non-simple variants in the future.

Simple enums with are now adjacently tagged:

```rust
#[non_exhaustive]
pub enum CompressionAlgorithm {
    Deflate,
}

#[non_exhaustive]
pub enum Utf8Kind {
    Accept,
    Only,
}

#[non_exhaustive]
pub enum Macro {
    Fast,
    All,
    Full,
}
```

Simple enums which are still externally tagged:

```rust
pub enum Depth {
    Null,
    One,
    Infinity,
}

pub enum EntryTypeReq {
    Private,
    Shared,
    All,
}

pub enum LiteralMode {
    Sync,
    NonSync,
}

pub enum StoreType {
    Replace,
    Add,
    Remove,
}

pub enum StoreResponse {
    Answer,
    Silent,
}

pub enum GreetingKind {
    Ok,
    PreAuth,
    Bye,
}

pub enum StatusKind {
    Ok,
    No,
    Bad,
}

pub enum SortKey {
    Arrival,
    Cc,
    Date,
    From,
    Size,
    Subject,
    To,
    DisplayFrom,
    DisplayTo,
}

// It's data is already separated into StatusDataItem
pub enum StatusDataItemName {
    Messages,
    Recent,
    UidNext,
    UidValidity,
    Unseen,
    Deleted,
    DeletedStorage,
    HighestModSeq,
}
```