### PR TITLE
feat: add NAMESPACE support

### DIFF
--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -74,6 +74,7 @@ ext_id = ["imap-types/ext_id"]
 ext_login_referrals = ["imap-types/ext_login_referrals"]
 ext_mailbox_referrals = ["imap-types/ext_mailbox_referrals"]
 ext_metadata = ["imap-types/ext_metadata"]
+ext_namespace = ["imap-types/ext_namespace"]
 ext_utf8 = ["imap-types/ext_utf8"]
 # </Forward to imap-types>
 

--- a/imap-codec/fuzz/Cargo.toml
+++ b/imap-codec/fuzz/Cargo.toml
@@ -24,6 +24,7 @@ ext_id = ["imap-codec/ext_id"]
 ext_login_referrals = ["imap-codec/ext_login_referrals"]
 ext_mailbox_referrals = ["imap-codec/ext_mailbox_referrals"]
 ext_metadata = ["imap-codec/ext_metadata"]
+ext_namespace = ["imap-codec/ext_namespace"]
 ext_utf8 = ["imap-codec/ext_utf8"]
 
 # IMAP quirks
@@ -39,6 +40,7 @@ ext = [
     #"ext_login_referrals",
     #"ext_mailbox_referrals",
     "ext_metadata",
+    "ext_namespace",
     "ext_utf8",
 ]
 # Enable `Debug`-printing during parsing. This is useful to analyze crashes.

--- a/imap-codec/src/codec/encode.rs
+++ b/imap-codec/src/codec/encode.rs
@@ -83,6 +83,8 @@ use imap_types::{
 };
 use utils::{List1AttributeValueOrNil, List1OrNil, join_serializable};
 
+#[cfg(feature = "ext_namespace")]
+use crate::extensions::namespace::encode_namespaces;
 use crate::{AuthenticateDataCodec, CommandCodec, GreetingCodec, IdleDoneCodec, ResponseCodec};
 
 /// Encoder.
@@ -685,6 +687,8 @@ impl EncodeIntoContext for CommandBody<'_> {
                     ctx.write_all(b")")
                 }
             }
+            #[cfg(feature = "ext_namespace")]
+            &CommandBody::Namespace => ctx.write_all(b"NAMESPACE"),
         }
     }
 }
@@ -1613,6 +1617,19 @@ impl EncodeIntoContext for Data<'_> {
                 }
                 ctx.write_all(b" ")?;
                 known_uids.encode_ctx(ctx)?;
+            }
+            #[cfg(feature = "ext_namespace")]
+            Data::Namespace {
+                personal,
+                other,
+                shared,
+            } => {
+                ctx.write_all(b"* NAMESPACE ")?;
+                encode_namespaces(ctx, personal)?;
+                ctx.write_all(b" ")?;
+                encode_namespaces(ctx, other)?;
+                ctx.write_all(b" ")?;
+                encode_namespaces(ctx, shared)?;
             }
         }
 

--- a/imap-codec/src/command.rs
+++ b/imap-codec/src/command.rs
@@ -38,6 +38,8 @@ use crate::extensions::condstore_qresync::mod_sequence_valzer;
 use crate::extensions::id::id;
 #[cfg(feature = "ext_metadata")]
 use crate::extensions::metadata::{getmetadata, setmetadata};
+#[cfg(feature = "ext_namespace")]
+use crate::extensions::namespace::namespace_command;
 use crate::{
     auth::auth_type,
     core::{astring, base64, literal, tag_imap},
@@ -168,6 +170,8 @@ pub(crate) fn command_auth(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
         setmetadata,
         #[cfg(feature = "ext_metadata")]
         getmetadata,
+        #[cfg(feature = "ext_namespace")]
+        namespace_command,
     ))(input)
 }
 

--- a/imap-codec/src/extensions.rs
+++ b/imap-codec/src/extensions.rs
@@ -10,6 +10,8 @@ pub mod literal;
 #[cfg(feature = "ext_metadata")]
 pub mod metadata;
 pub mod r#move;
+#[cfg(feature = "ext_namespace")]
+pub mod namespace;
 pub mod quota;
 pub mod sort;
 pub mod thread;

--- a/imap-codec/src/extensions/namespace.rs
+++ b/imap-codec/src/extensions/namespace.rs
@@ -1,0 +1,191 @@
+//! The IMAP NAMESPACE Extension
+
+use std::io::Write;
+
+use abnf_core::streaming::{dquote, sp};
+use imap_types::{
+    command::CommandBody,
+    core::Vec1,
+    extensions::namespace::{Namespace, NamespaceResponseExtension, Namespaces},
+    response::Data,
+};
+use nom::{
+    branch::alt,
+    bytes::streaming::tag_no_case,
+    character::streaming::char,
+    combinator::{map, value},
+    multi::{many0, many1, separated_list1},
+    sequence::{delimited, preceded, tuple},
+};
+
+use crate::{
+    core::{nil, quoted_char, string},
+    decode::IMAPResult,
+    encode::{EncodeContext, EncodeIntoContext},
+};
+
+/// ```abnf
+/// namespace = "NAMESPACE"
+/// ```
+pub(crate) fn namespace_command(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
+    value(CommandBody::Namespace, tag_no_case(b"NAMESPACE"))(input)
+}
+
+/// ```abnf
+/// ;; The first Namespace is the Personal Namespace(s)
+/// ;; The second Namespace is the Other Users' Namespace(s)
+/// ;; The third Namespace is the Shared Namespace(s)
+/// Namespace-Response = "NAMESPACE" SP Namespace SP Namespace SP Namespace
+/// ```
+pub(crate) fn namespace_response(input: &[u8]) -> IMAPResult<&[u8], Data> {
+    let mut parser = tuple((
+        tag_no_case("NAMESPACE "),
+        namespace,
+        preceded(sp, namespace),
+        preceded(sp, namespace),
+    ));
+
+    let (remaining, (_, personal, other, shared)) = parser(input)?;
+
+    Ok((
+        remaining,
+        Data::Namespace {
+            personal,
+            other,
+            shared,
+        },
+    ))
+}
+
+/// ```abnf
+/// Namespace = nil / "(" 1*Namespace-Descr ")"
+/// ```
+fn namespace(input: &[u8]) -> IMAPResult<&[u8], Namespaces> {
+    alt((
+        map(nil, |_| Vec::new()),
+        delimited(char('('), many1(namespace_descr), char(')')),
+    ))(input)
+}
+
+/// ```abnf
+/// Namespace-Descr = "("
+///                     string
+///                     SP
+///                     (DQUOTE QUOTED-CHAR DQUOTE / nil)
+///                     *(Namespace-Response-Extension)
+///                   ")"
+/// ```
+fn namespace_descr(input: &[u8]) -> IMAPResult<&[u8], Namespace> {
+    map(
+        delimited(
+            char('('),
+            tuple((
+                string,
+                sp,
+                alt((
+                    map(delimited(dquote, quoted_char, dquote), Some),
+                    value(None, nil),
+                )),
+                many0(namespace_response_extension),
+            )),
+            char(')'),
+        ),
+        |(prefix, _, delimiter, extensions)| Namespace {
+            prefix,
+            delimiter,
+            extensions,
+        },
+    )(input)
+}
+
+/// ```abnf
+/// Namespace-Response-Extension = SP string SP "(" string *(SP string) ")"
+/// ```
+fn namespace_response_extension(input: &[u8]) -> IMAPResult<&[u8], NamespaceResponseExtension> {
+    map(
+        tuple((
+            preceded(sp, string),
+            preceded(
+                sp,
+                delimited(char('('), separated_list1(sp, string), char(')')),
+            ),
+        )),
+        |(key, values)| NamespaceResponseExtension {
+            key,
+            // We can use `unvalidated` because we know the vector has at least one element due to the `separated_list1` call above.
+            values: Vec1::unvalidated(values),
+        },
+    )(input)
+}
+
+impl EncodeIntoContext for Namespace<'_> {
+    fn encode_ctx(&self, ctx: &mut EncodeContext) -> std::io::Result<()> {
+        write!(ctx, "(")?;
+        self.prefix.encode_ctx(ctx)?;
+        write!(ctx, " ")?;
+
+        match &self.delimiter {
+            Some(delimiter_char) => {
+                write!(ctx, "\"")?;
+                delimiter_char.encode_ctx(ctx)?;
+                write!(ctx, "\"")?;
+            }
+            None => {
+                ctx.write_all(b"NIL")?;
+            }
+        }
+
+        for ext in &self.extensions {
+            ext.encode_ctx(ctx)?;
+        }
+
+        write!(ctx, ")")
+    }
+}
+
+impl EncodeIntoContext for NamespaceResponseExtension<'_> {
+    fn encode_ctx(&self, ctx: &mut EncodeContext) -> std::io::Result<()> {
+        write!(ctx, " ")?;
+        self.key.encode_ctx(ctx)?;
+
+        write!(ctx, " (")?;
+        if let Some((last, head)) = self.values.as_ref().split_last() {
+            for value in head {
+                value.encode_ctx(ctx)?;
+                write!(ctx, " ")?;
+            }
+            last.encode_ctx(ctx)?;
+        }
+        write!(ctx, ")")
+    }
+}
+
+pub fn encode_namespaces(ctx: &mut EncodeContext, list: &Namespaces<'_>) -> std::io::Result<()> {
+    if list.is_empty() {
+        ctx.write_all(b"NIL")
+    } else {
+        ctx.write_all(b"(")?;
+        for desc in list {
+            desc.encode_ctx(ctx)?;
+        }
+        ctx.write_all(b")")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::namespace_response;
+
+    #[test]
+    fn parse_namespace_response() {
+        let tests = [
+            b"NAMESPACE ((\"0\" \"\\\"\")) NIL NIL\r\n".as_ref(),
+            #[cfg(feature = "ext_utf8")]
+            b"NAMESPACE ((\"^^\x00\" \"\x07\")) NIL NIL\r\n",
+        ];
+
+        for test in tests.into_iter() {
+            namespace_response(test).unwrap();
+        }
+    }
+}

--- a/imap-codec/src/mailbox.rs
+++ b/imap-codec/src/mailbox.rs
@@ -20,6 +20,8 @@ use nom::{
 use crate::extensions::condstore_qresync::search_sort_mod_seq;
 #[cfg(feature = "ext_metadata")]
 use crate::extensions::metadata::metadata_resp;
+#[cfg(feature = "ext_namespace")]
+use crate::extensions::namespace::namespace_response;
 use crate::{
     core::{astring, nil, number, nz_number, quoted_char, string},
     decode::IMAPResult,
@@ -168,6 +170,8 @@ pub(crate) fn mailbox_data(input: &[u8]) -> IMAPResult<&[u8], Data> {
         ),
         #[cfg(feature = "ext_metadata")]
         metadata_resp,
+        #[cfg(feature = "ext_namespace")]
+        namespace_response,
         map(terminated(number, tag_no_case(b" EXISTS")), Data::Exists),
         map(terminated(number, tag_no_case(b" RECENT")), Data::Recent),
         quotaroot_response,

--- a/imap-types/Cargo.toml
+++ b/imap-types/Cargo.toml
@@ -26,6 +26,7 @@ ext_id = []
 ext_login_referrals = []
 ext_mailbox_referrals = []
 ext_metadata = []
+ext_namespace = []
 ext_utf8 = []
 
 [dependencies]

--- a/imap-types/fuzz/Cargo.toml
+++ b/imap-types/fuzz/Cargo.toml
@@ -20,6 +20,7 @@ ext_id = ["imap-types/ext_id"]
 ext_login_referrals = ["imap-types/ext_login_referrals"]
 ext_mailbox_referrals = ["imap-types/ext_mailbox_referrals"]
 ext_metadata = ["imap-types/ext_metadata"]
+ext_namespace = ["imap-types/ext_namespace"]
 ext_utf8 = ["imap-types/ext_utf8"]
 # </Forward to imap-types>
 
@@ -31,6 +32,7 @@ ext = [
     #"ext_login_referrals",
     #"ext_mailbox_referrals",
     "ext_metadata",
+    "ext_namespace",
     "ext_utf8",
 ]
 # Enable `Debug`-printing during parsing. This is useful to analyze crashes.

--- a/imap-types/src/command.rs
+++ b/imap-types/src/command.rs
@@ -1536,6 +1536,13 @@ pub enum CommandBody<'a> {
         mailbox: Mailbox<'a>,
         entries: Vec1<Entry<'a>>,
     },
+    #[cfg(feature = "ext_namespace")]
+    /// Retrieve the namespaces available to the client.
+    ///
+    /// <div class="warning">
+    /// This extension must only be used when the server advertised support for it sending the NAMESPACE capability.
+    /// </div>
+    Namespace,
 }
 
 impl<'a> CommandBody<'a> {
@@ -1840,6 +1847,8 @@ impl<'a> CommandBody<'a> {
             Self::SetMetadata { .. } => "SETMETADATA",
             #[cfg(feature = "ext_metadata")]
             Self::GetMetadata { .. } => "GETMETADATA",
+            #[cfg(feature = "ext_namespace")]
+            Self::Namespace => "NAMESPACE",
         }
     }
 }

--- a/imap-types/src/extensions.rs
+++ b/imap-types/src/extensions.rs
@@ -9,6 +9,8 @@ pub mod idle;
 #[cfg(feature = "ext_metadata")]
 pub mod metadata;
 pub mod r#move;
+#[cfg(feature = "ext_namespace")]
+pub mod namespace;
 pub mod quota;
 pub mod sort;
 pub mod thread;

--- a/imap-types/src/extensions/namespace.rs
+++ b/imap-types/src/extensions/namespace.rs
@@ -1,0 +1,111 @@
+//! The IMAP NAMESPACE Extension
+//!
+//! This extends ...
+//!
+//! * [`Capability`](crate::response::Capability) with a new variant:
+//!
+//!     - [`Capability::Namespace`](crate::response::Capability::Namespace)
+//!
+//! * [`CommandBody`] with a new variant:
+//!
+//!     - [`CommandBody::Namespace`]
+//!
+//! * [`Data`] with a new variant:
+//!
+//!     - [`Data::Namespace`]
+
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+use bounded_static_derive::ToStatic;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    command::CommandBody,
+    core::{IString, QuotedChar, Vec1},
+    extensions::namespace::error::NamespaceError,
+    response::Data,
+};
+
+impl<'a> CommandBody<'a> {
+    /// <div class="warning">
+    /// This extension must only be used when the server advertised support for it by sending the NAMESPACE capability.
+    /// </div>
+    pub fn namespace() -> Self {
+        CommandBody::Namespace
+    }
+}
+
+impl<'a> Data<'a> {
+    #[allow(clippy::type_complexity)]
+    pub fn namespace<P, O, S>(
+        personal: P,
+        other: O,
+        shared: S,
+    ) -> Result<Self, NamespaceError<P::Error, O::Error, S::Error>>
+    where
+        P: TryInto<Namespaces<'a>>,
+        O: TryInto<Namespaces<'a>>,
+        S: TryInto<Namespaces<'a>>,
+    {
+        Ok(Self::Namespace {
+            personal: personal.try_into().map_err(NamespaceError::Personal)?,
+            other: other.try_into().map_err(NamespaceError::Other)?,
+            shared: shared.try_into().map_err(NamespaceError::Shared)?,
+        })
+    }
+}
+
+/// A list of `Namespace` definitions.
+///
+/// Corresponds to the `Namespace` rule in the ABNF, which is either `NIL`
+/// or a parenthesized list of namespace descriptions. An empty `Vec` is treated as `NIL`.
+pub type Namespaces<'a> = Vec<Namespace<'a>>;
+
+/// A single namespace's description, containing a prefix, delimiter, and optional extensions.
+///
+/// Corresponds to the `( string SP (<"> QUOTED_CHAR <"> / nil) *(Namespace_Response_Extension) )`
+/// part of the ABNF.
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
+pub struct Namespace<'a> {
+    pub prefix: IString<'a>,
+    pub delimiter: Option<QuotedChar>,
+    /// Optional extension data for this namespace.
+    pub extensions: Vec<NamespaceResponseExtension<'a>>,
+}
+
+impl<'a> Namespace<'a> {
+    pub fn new(prefix: IString<'a>, delimiter: Option<QuotedChar>) -> Self {
+        Self {
+            prefix,
+            delimiter,
+            extensions: Vec::new(),
+        }
+    }
+}
+
+/// Extension data for a namespace response.
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
+pub struct NamespaceResponseExtension<'a> {
+    pub key: IString<'a>,
+    pub values: Vec1<IString<'a>>,
+}
+
+/// Error-related types.
+pub mod error {
+    use thiserror::Error;
+
+    #[derive(Clone, Debug, Eq, Error, Hash, Ord, PartialEq, PartialOrd)]
+    pub enum NamespaceError<P, O, S> {
+        #[error("Invalid personal namespace: {0}")]
+        Personal(P),
+        #[error("Invalid other namespace: {0}")]
+        Other(O),
+        #[error("Invalid shared namespace: {0}")]
+        Shared(S),
+    }
+}

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -19,6 +19,8 @@ use serde::{Deserialize, Serialize};
 use crate::core::{IString, NString};
 #[cfg(feature = "ext_metadata")]
 use crate::extensions::metadata::{MetadataCode, MetadataResponse};
+#[cfg(feature = "ext_namespace")]
+use crate::extensions::namespace::Namespaces;
 #[cfg(feature = "ext_utf8")]
 use crate::extensions::utf8::Utf8Kind;
 #[cfg(feature = "ext_condstore_qresync")]
@@ -595,6 +597,13 @@ pub enum Data<'a> {
         earlier: bool,
         known_uids: SequenceSet,
     },
+
+    #[cfg(feature = "ext_namespace")]
+    Namespace {
+        personal: Namespaces<'a>,
+        other: Namespaces<'a>,
+        shared: Namespaces<'a>,
+    },
 }
 
 impl<'a> Data<'a> {
@@ -1103,6 +1112,9 @@ pub enum Capability<'a> {
     /// QRESYNC extension (RFC 7162)
     #[cfg(feature = "ext_condstore_qresync")]
     QResync,
+    /// NAMESPACE extension (RFC 2342)
+    #[cfg(feature = "ext_namespace")]
+    Namespace,
     #[cfg(feature = "ext_utf8")]
     Utf8(Utf8Kind),
     /// Other/Unknown
@@ -1147,6 +1159,8 @@ impl Display for Capability<'_> {
             Self::CondStore => write!(f, "CONDSTORE"),
             #[cfg(feature = "ext_condstore_qresync")]
             Self::QResync => write!(f, "QRESYNC"),
+            #[cfg(feature = "ext_namespace")]
+            Self::Namespace => write!(f, "NAMESPACE"),
             #[cfg(feature = "ext_utf8")]
             Self::Utf8(kind) => write!(f, "UTF8={kind}"),
             Self::Other(other) => write!(f, "{}", other.0),

--- a/justfile
+++ b/justfile
@@ -54,10 +54,11 @@ cargo_hack mode: install_cargo_hack
         --group-features \
         starttls,\
         ext_condstore_qresync,\
+        ext_id,\
         ext_login_referrals,\
         ext_mailbox_referrals,\
-        ext_id,\
         ext_metadata,\
+        ext_namespace,\
         ext_utf8 \
         --group-features \
         quirk_crlf_relaxed,\
@@ -84,10 +85,11 @@ cargo_hack mode: install_cargo_hack
         --group-features \
         starttls,\
         ext_condstore_qresync,\
+        ext_id,\
         ext_login_referrals,\
         ext_mailbox_referrals,\
-        ext_id,\
         ext_metadata,\
+        ext_namespace,\
         ext_utf8\
         {{ mode }}
 	


### PR DESCRIPTION
Hey @qbit-0! I fixed up some minor issues and started to fuzz imap-codec with ...

```sh
cd imap-codec/fuzz
cargo +nightly fuzz run --features=ext response_to_bytes_and_back
```

... to check that our NAMESPACE extension never generates invalid data.

The fuzzer found a few minor issues, e.g., missing quoting of "quoted_char", but these should be fixed now. I also changed `astring` to `istring` according to the spec.

I kept you as the main author and made me a co-author of the commit. Are you fine with that?

Thanks again for your great work!