### PR TITLE
refactor: replace warn! by debug!

### DIFF
--- a/imap-codec/src/body.rs
+++ b/imap-codec/src/body.rs
@@ -298,7 +298,7 @@ pub(crate) fn body_fld_octets(input: &[u8]) -> IMAPResult<&[u8], u32> {
         return alt((
             number,
             map(tuple((tag("-"), number)), |(_, _)| {
-                log::warn!("Rectified negative number to 0");
+                log::debug!("Rectified negative number to 0");
                 0
             }),
         ))(input);

--- a/imap-codec/src/response.rs
+++ b/imap-codec/src/response.rs
@@ -110,7 +110,7 @@ pub(crate) fn resp_text(input: &[u8]) -> IMAPResult<&[u8], (Option<Code>, Text)>
             alt((
                 preceded(sp, text),
                 map(peek(crlf), |_| {
-                    log::warn!("Rectified missing `text` to \"...\"");
+                    log::debug!("Rectified missing `text` to \"...\"");
 
                     Text::unvalidated("...")
                 }),
@@ -271,7 +271,7 @@ pub(crate) fn response(input: &[u8]) -> IMAPResult<&[u8], Response> {
 pub(crate) fn empty_continue_req(input: &[u8]) -> IMAPResult<&[u8], CommandContinuationRequest> {
     let mut parser = tuple((tag(b"+"), crlf));
     let (remaining, _) = parser(input)?;
-    log::warn!("Rectified faulty continuation request `+\r\n` to `+ ...\r\n`");
+    log::debug!("Rectified faulty continuation request `+\r\n` to `+ ...\r\n`");
     let req = CommandContinuationRequest::basic(None, "...").unwrap();
 
     Ok((remaining, req))


### PR DESCRIPTION
I propose to replace `warn!` by `debug!` after few discussions I got with Himalaya users. A warn is often seen as something important, sometimes even invasive, and that can be solved by users (for example, a missing configuration or a insecure setting). In `imap-codec` context, there is nothing that a lib consumer can do about a rectified malformed message. At this stage it could even be a `trace!`. Curious to know your opinion.