### PR TITLE
fix: Capability atom conversion for CONDSTORE / QRESYNC

### DIFF
--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -1227,9 +1227,9 @@ impl<'a> From<Atom<'a>> for Capability<'a> {
             "binary" => Self::Binary,
             "unselect" => Self::Unselect,
             #[cfg(feature = "ext_condstore_qresync")]
-            "condstore" => Self::Unselect,
+            "condstore" => Self::CondStore,
             #[cfg(feature = "ext_condstore_qresync")]
-            "qresync" => Self::Unselect,
+            "qresync" => Self::QResync,
             "uidplus" => Self::UidPlus,
             #[cfg(feature = "ext_utf8")]
             "utf8=accept" => Self::Utf8(Utf8Kind::Accept),


### PR DESCRIPTION
The atoms `CONDSTORE` and `QRESYNC` are incorrectly converted to `Data::Capability::Unselect` instead of `Data::Capability::CondStore` and `Data::Capability::QResync` respectively.

I noticed this bug (introduced in #629) when trying to use [pimalaya/imap-client to list capabilities](https://github.com/pimalaya/imap-client/blob/master/src/tasks/tasks/capability.rs) and it reported my IMAP server didn't have CONDSTORE, even though other clients report it correctly.

Here is a small proof-of-concept example to demonstrate the bug / fix:
`$ cargo run --features ext_condstore_qresync --example condstore_qresync`

```
# examples/condstore_qresync.rs
use imap_types::{core::Atom, response::Capability};

fn main() {
    let test_cases = vec!["IMAP4REV1", "CONDSTORE", "QRESYNC", "UNSELECT", "ENABLE"];

    for capability_str in test_cases {
        let atom = Atom::try_from(capability_str).unwrap();
        let capability = Capability::from(atom);

        println!(
            "Input: {:15} -> Parsed as: {:?}",
            capability_str, capability
        );
    }
}
```

Before:
```
Input: IMAP4REV1       -> Parsed as: Imap4Rev1
Input: CONDSTORE       -> Parsed as: Unselect <-- wrong
Input: QRESYNC         -> Parsed as: Unselect <-- wrong
Input: UNSELECT        -> Parsed as: Unselect
Input: ENABLE          -> Parsed as: Enable
```

After:
```
Input: IMAP4REV1       -> Parsed as: Imap4Rev1
Input: CONDSTORE       -> Parsed as: CondStore <-- correct
Input: QRESYNC         -> Parsed as: QResync <-- correct
Input: UNSELECT        -> Parsed as: Unselect
Input: ENABLE          -> Parsed as: Enable
```
