### PR TITLE
`LIST-EXTENDED`, part 3: mailbox types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "imap-codec"
-version = "2.0.0-alpha.8"
+version = "2.0.0-alpha.9"
 dependencies = [
  "abnf-core",
  "base64 0.22.1",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "imap-types"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/imap-types/src/mailbox.rs
+++ b/imap-types/src/mailbox.rs
@@ -9,7 +9,7 @@ use bounded_static_derive::ToStatic;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    core::{AString, IString, impl_try_from},
+    core::{AString, IString, Vec1, impl_try_from},
     error::{ValidationError, ValidationErrorKind},
     mailbox::error::MailboxOtherError,
     utils::indicators::is_list_char,
@@ -127,6 +127,54 @@ impl TryFrom<String> for ListMailbox<'_> {
         }
 
         Ok(ListMailbox::String(s.try_into()?))
+    }
+}
+
+/// The mailbox pattern argument of the extended `LIST` command (`mbox-or-pat`).
+///
+/// ```abnf
+/// mbox-or-pat = list-mailbox / patterns
+/// patterns = "(" list-mailbox *(SP list-mailbox) ")"
+/// ```
+///
+/// A plain (non-extended) `LIST` command always uses the [`Single`] form. The
+/// parenthesized pattern [`Multi`] form requires the `LIST-EXTENDED` extension.
+///
+/// See [RFC 5258, section 3](https://www.rfc-editor.org/rfc/rfc5258#section-3).
+///
+/// [`Single`]: MboxOrPat::Single
+/// [`Multi`]: MboxOrPat::Multi
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "content"))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ToStatic)]
+pub enum MboxOrPat<'a> {
+    /// A single, unparenthesized mailbox pattern.
+    Single(ListMailbox<'a>),
+
+    /// A parenthesized, non-empty list of mailbox patterns.
+    Multi(Vec1<ListMailbox<'a>>),
+}
+
+impl<'a> From<ListMailbox<'a>> for MboxOrPat<'a> {
+    fn from(mailbox: ListMailbox<'a>) -> Self {
+        MboxOrPat::Single(mailbox)
+    }
+}
+
+impl<'a> TryFrom<&'a str> for MboxOrPat<'a> {
+    type Error = ValidationError;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        Ok(MboxOrPat::Single(ListMailbox::try_from(s)?))
+    }
+}
+
+impl TryFrom<String> for MboxOrPat<'_> {
+    type Error = ValidationError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Ok(MboxOrPat::Single(ListMailbox::try_from(s)?))
     }
 }
 
@@ -364,5 +412,30 @@ mod tests {
             err.to_string(),
             r"Reserved: Please use one of the typed variants"
         );
+    }
+
+    #[test]
+    fn test_conversion_mbox_or_pat() {
+        assert_eq!(
+            MboxOrPat::try_from("*").unwrap(),
+            MboxOrPat::Single(ListMailbox::try_from("*").unwrap())
+        );
+        assert_eq!(
+            MboxOrPat::try_from("%".to_string()).unwrap(),
+            MboxOrPat::Single(ListMailbox::try_from("%").unwrap())
+        );
+        assert_eq!(
+            MboxOrPat::from(ListMailbox::try_from("foo").unwrap()),
+            MboxOrPat::Single(ListMailbox::try_from("foo").unwrap())
+        );
+
+        let patterns = MboxOrPat::Multi(
+            Vec1::try_from(vec![
+                ListMailbox::try_from("foo").unwrap(),
+                ListMailbox::try_from("bar/%").unwrap(),
+            ])
+            .unwrap(),
+        );
+        assert!(matches!(patterns, MboxOrPat::Multi(_)));
     }
 }


### PR DESCRIPTION
Part 2: https://github.com/duesee/imap-codec/pull/717

This part 3 adds the mailbox-related types.

Refs: #350 