### PR TITLE
feat: add WITHIN search keys

### DIFF
--- a/imap-codec/Cargo.toml
+++ b/imap-codec/Cargo.toml
@@ -80,6 +80,7 @@ ext_metadata = ["imap-types/ext_metadata"]
 ext_namespace = ["imap-types/ext_namespace"]
 ext_status_size = ["imap-types/ext_status_size"]
 ext_utf8 = ["imap-types/ext_utf8"]
+ext_within = ["imap-types/ext_within"]
 # </Forward to imap-types>
 
 [dependencies]

--- a/imap-codec/fuzz/Cargo.toml
+++ b/imap-codec/fuzz/Cargo.toml
@@ -27,6 +27,7 @@ ext_metadata = ["imap-codec/ext_metadata"]
 ext_namespace = ["imap-codec/ext_namespace"]
 ext_status_size = ["imap-codec/ext_status_size"]
 ext_utf8 = ["imap-codec/ext_utf8"]
+ext_within = ["imap-codec/ext_within"]
 
 # IMAP quirks
 quirk_crlf_relaxed = ["imap-codec/quirk_crlf_relaxed"]
@@ -44,6 +45,7 @@ ext = [
     "ext_namespace",
     "ext_status_size",
     "ext_utf8",
+    "ext_within",
 ]
 # Enable `Debug`-printing during parsing. This is useful to analyze crashes.
 debug = []

--- a/imap-codec/src/codec/encode.rs
+++ b/imap-codec/src/codec/encode.rs
@@ -1000,6 +1000,10 @@ impl EncodeIntoContext for SearchKey<'_> {
                 date.encode_ctx(ctx)
             }
             SearchKey::Smaller(number) => write!(ctx, "SMALLER {number}"),
+            #[cfg(feature = "ext_within")]
+            SearchKey::Older(seconds) => write!(ctx, "OLDER {seconds}"),
+            #[cfg(feature = "ext_within")]
+            SearchKey::Younger(seconds) => write!(ctx, "YOUNGER {seconds}"),
             SearchKey::Uid(sequence_set) => {
                 ctx.write_all(b"UID ")?;
                 sequence_set.encode_ctx(ctx)

--- a/imap-codec/src/response.rs
+++ b/imap-codec/src/response.rs
@@ -518,6 +518,14 @@ mod tests {
                     Data::capability(vec![Capability::Imap4Rev1, Capability::StatusSize]).unwrap(),
                 ),
             ),
+            #[cfg(feature = "ext_within")]
+            (
+                b"* CAPABILITY IMAP4REV1 WITHIN\r\n".as_ref(),
+                b"".as_ref(),
+                Response::Data(
+                    Data::capability(vec![Capability::Imap4Rev1, Capability::Within]).unwrap(),
+                ),
+            ),
             (
                 b"* LIST (\\Noselect) \"/\" bbb\r\n",
                 b"",

--- a/imap-codec/src/search.rs
+++ b/imap-codec/src/search.rs
@@ -12,6 +12,8 @@ use nom::{
     sequence::{delimited, separated_pair, tuple},
 };
 
+#[cfg(feature = "ext_within")]
+use crate::core::nz_number;
 #[cfg(feature = "ext_condstore_qresync")]
 use crate::extensions::condstore_qresync::search_modsequence;
 use crate::{
@@ -63,6 +65,7 @@ pub(crate) fn search(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 ///              "KEYWORD" SP flag-keyword /
 ///              "NEW" /
 ///              "OLD" /
+///              "OLDER" SP nz-number / ; RFC 5032
 ///              "ON" SP date /
 ///              "RECENT" /
 ///              "SEEN" /
@@ -87,6 +90,7 @@ pub(crate) fn search(input: &[u8]) -> IMAPResult<&[u8], CommandBody> {
 ///              "SMALLER" SP number /
 ///              "UID" SP sequence-set /
 ///              "UNDRAFT" /
+///              "YOUNGER" SP nz-number / ; RFC 5032
 ///              search-modsequence / ; RFC 7162
 ///              sequence-set /
 ///              "(" search-key *(SP search-key) ")"
@@ -140,6 +144,12 @@ fn search_key_limited(input: &[u8], remaining_recursion: usize) -> IMAPResult<&[
                 |(_, _, val)| SearchKey::Keyword(val),
             ),
             value(SearchKey::New, tag_no_case(b"NEW")),
+            // Match OLDER before OLD.
+            #[cfg(feature = "ext_within")]
+            map(
+                tuple((tag_no_case(b"OLDER"), sp, nz_number)),
+                |(_, _, val)| SearchKey::Older(val),
+            ),
             value(SearchKey::Old, tag_no_case(b"OLD")),
             map(
                 tuple((tag_no_case(b"ON"), sp, map_opt(date, |date| date))),
@@ -211,6 +221,11 @@ fn search_key_limited(input: &[u8], remaining_recursion: usize) -> IMAPResult<&[
                 tuple((tag_no_case(b"UID"), sp, sequence_set)),
                 |(_, _, val)| SearchKey::Uid(val),
             ),
+            #[cfg(feature = "ext_within")]
+            map(
+                tuple((tag_no_case(b"YOUNGER"), sp, nz_number)),
+                |(_, _, val)| SearchKey::Younger(val),
+            ),
             value(SearchKey::Undraft, tag_no_case(b"UNDRAFT")),
             #[cfg(feature = "ext_condstore_qresync")]
             map(search_modsequence, |(entry, modseq)| {
@@ -242,6 +257,9 @@ pub(crate) fn search_criteria(input: &[u8]) -> IMAPResult<&[u8], (Charset, Vec1<
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "ext_within")]
+    use std::num::NonZeroU32;
+
     use imap_types::{
         core::{AString, Atom},
         datetime::NaiveDate,
@@ -249,7 +267,48 @@ mod tests {
     };
 
     use super::*;
+    #[cfg(feature = "ext_within")]
+    use crate::testing::kat_inverse_command;
     use crate::testing::known_answer_test_encode;
+
+    #[cfg(feature = "ext_within")]
+    #[test]
+    fn test_kat_inverse_search_within() {
+        kat_inverse_command(&[
+            (
+                b"a1 SEARCH UNSEEN YOUNGER 259200\r\n",
+                b"",
+                CommandBody::Search {
+                    charset: None,
+                    criteria: vec![
+                        SearchKey::Unseen,
+                        SearchKey::Younger(NonZeroU32::new(259200).unwrap()),
+                    ]
+                    .try_into()
+                    .unwrap(),
+                    uid: false,
+                }
+                .tag("a1")
+                .unwrap(),
+            ),
+            (
+                b"A2 SEARCH OLDER 4294967295 OLD\r\n",
+                b"",
+                CommandBody::Search {
+                    charset: None,
+                    criteria: vec![
+                        SearchKey::Older(NonZeroU32::new(u32::MAX).unwrap()),
+                        SearchKey::Old,
+                    ]
+                    .try_into()
+                    .unwrap(),
+                    uid: false,
+                }
+                .tag("A2")
+                .unwrap(),
+            ),
+        ]);
+    }
 
     #[test]
     fn test_parse_search() {
@@ -367,6 +426,13 @@ mod tests {
             ),
             (SearchKey::Larger(42), b"LARGER 42"),
             (SearchKey::New, b"NEW"),
+            #[cfg(feature = "ext_within")]
+            (SearchKey::Older(NonZeroU32::new(42).unwrap()), b"OLDER 42"),
+            #[cfg(feature = "ext_within")]
+            (
+                SearchKey::Younger(NonZeroU32::new(42).unwrap()),
+                b"YOUNGER 42",
+            ),
             (SearchKey::Not(Box::new(SearchKey::New)), b"NOT NEW"),
             (SearchKey::Old, b"OLD"),
             (

--- a/imap-types/Cargo.toml
+++ b/imap-types/Cargo.toml
@@ -29,6 +29,7 @@ ext_metadata = []
 ext_namespace = []
 ext_status_size = []
 ext_utf8 = []
+ext_within = []
 
 [dependencies]
 arbitrary = { version = "1.4.2", optional = true, default-features = false, features = ["derive"] }

--- a/imap-types/fuzz/Cargo.toml
+++ b/imap-types/fuzz/Cargo.toml
@@ -23,6 +23,7 @@ ext_metadata = ["imap-types/ext_metadata"]
 ext_namespace = ["imap-types/ext_namespace"]
 ext_status_size = ["imap-types/ext_status_size"]
 ext_utf8 = ["imap-types/ext_utf8"]
+ext_within = ["imap-types/ext_within"]
 # </Forward to imap-types>
 
 # Use (most) IMAP extensions.
@@ -36,6 +37,7 @@ ext = [
     "ext_namespace",
     "ext_status_size",
     "ext_utf8",
+    "ext_within",
 ]
 # Enable `Debug`-printing during parsing. This is useful to analyze crashes.
 debug = []

--- a/imap-types/src/arbitrary.rs
+++ b/imap-types/src/arbitrary.rs
@@ -234,11 +234,11 @@ fn arbitrary_search_key_limited<'a>(
         return arbitrary_search_key_leaf(u);
     }
 
-    let till = if cfg!(feature = "ext_condstore_qresync") {
-        37
-    } else {
-        36
-    };
+    let till = 36;
+    #[cfg(feature = "ext_within")]
+    let till = till + 2; // OLDER and YOUNGER
+    #[cfg(feature = "ext_condstore_qresync")]
+    let till = till + 1; // MODSEQ
 
     Ok(match u.int_in_range(0u8..=till)? {
         0 => SearchKey::And({
@@ -298,8 +298,12 @@ fn arbitrary_search_key_limited<'a>(
         34 => SearchKey::Unflagged,
         35 => SearchKey::Unkeyword(Atom::arbitrary(u)?),
         36 => SearchKey::Unseen,
+        #[cfg(feature = "ext_within")]
+        37 => SearchKey::Older(Arbitrary::arbitrary(u)?),
+        #[cfg(feature = "ext_within")]
+        38 => SearchKey::Younger(Arbitrary::arbitrary(u)?),
         #[cfg(feature = "ext_condstore_qresync")]
-        37 => SearchKey::ModSequence {
+        value if value == till => SearchKey::ModSequence {
             entry: Arbitrary::arbitrary(u)?,
             modseq: Arbitrary::arbitrary(u)?,
         },
@@ -308,7 +312,11 @@ fn arbitrary_search_key_limited<'a>(
 }
 
 fn arbitrary_search_key_leaf<'a>(u: &mut Unstructured<'a>) -> arbitrary::Result<SearchKey<'a>> {
-    Ok(match u.int_in_range(0u8..=33)? {
+    let till = 33;
+    #[cfg(feature = "ext_within")]
+    let till = till + 2; // OLDER and YOUNGER
+
+    Ok(match u.int_in_range(0u8..=till)? {
         0 => SearchKey::SequenceSet(SequenceSet::arbitrary(u)?),
         1 => SearchKey::All,
         2 => SearchKey::Answered,
@@ -343,6 +351,10 @@ fn arbitrary_search_key_leaf<'a>(u: &mut Unstructured<'a>) -> arbitrary::Result<
         31 => SearchKey::Unflagged,
         32 => SearchKey::Unkeyword(Atom::arbitrary(u)?),
         33 => SearchKey::Unseen,
+        #[cfg(feature = "ext_within")]
+        34 => SearchKey::Older(Arbitrary::arbitrary(u)?),
+        #[cfg(feature = "ext_within")]
+        35 => SearchKey::Younger(Arbitrary::arbitrary(u)?),
         _ => unreachable!(),
     })
 }

--- a/imap-types/src/response.rs
+++ b/imap-types/src/response.rs
@@ -1111,6 +1111,9 @@ pub enum Capability<'a> {
     StatusSize,
     #[cfg(feature = "ext_utf8")]
     Utf8(Utf8Kind),
+    /// WITHIN extension (RFC 5032)
+    #[cfg(feature = "ext_within")]
+    Within,
     /// Other/Unknown
     Other(CapabilityOther<'a>),
 }
@@ -1160,6 +1163,8 @@ impl Display for Capability<'_> {
             Self::StatusSize => write!(f, "STATUS=SIZE"),
             #[cfg(feature = "ext_utf8")]
             Self::Utf8(kind) => write!(f, "UTF8={kind}"),
+            #[cfg(feature = "ext_within")]
+            Self::Within => write!(f, "WITHIN"),
             Self::Other(other) => write!(f, "{}", other.0),
         }
     }
@@ -1235,6 +1240,8 @@ impl<'a> From<Atom<'a>> for Capability<'a> {
             "utf8=accept" => Self::Utf8(Utf8Kind::Accept),
             #[cfg(feature = "ext_utf8")]
             "utf8=only" => Self::Utf8(Utf8Kind::Only),
+            #[cfg(feature = "ext_within")]
+            "within" => Self::Within,
             _ => {
                 // TODO(efficiency)
                 if let Some((left, right)) = split_once_cow(cow.clone(), "=") {
@@ -1336,6 +1343,16 @@ mod tests {
             Capability::StatusSize,
         );
         assert_eq!(Capability::StatusSize.to_string(), "STATUS=SIZE");
+    }
+
+    #[cfg(feature = "ext_within")]
+    #[test]
+    fn test_capability_within() {
+        assert_eq!(
+            Capability::from(Atom::try_from("within").unwrap()),
+            Capability::Within,
+        );
+        assert_eq!(Capability::Within.to_string(), "WITHIN");
     }
 
     #[test]

--- a/imap-types/src/search.rs
+++ b/imap-types/src/search.rs
@@ -1,5 +1,8 @@
 //! Search-related types.
 
+#[cfg(feature = "ext_within")]
+use std::num::NonZeroU32;
+
 use bounded_static_derive::ToStatic;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -95,6 +98,12 @@ pub enum SearchKey<'a> {
     /// NEW").
     Old,
 
+    #[cfg(feature = "ext_within")]
+    /// Messages whose internal date is less recent than or equal to the current
+    /// date and time of the server minus the interval, specified in seconds
+    /// [RFC-5032].
+    Older(NonZeroU32),
+
     /// Messages whose internal date (disregarding time and timezone)
     /// is within the specified date.
     On(NaiveDate),
@@ -161,6 +170,12 @@ pub enum SearchKey<'a> {
 
     /// Messages that do not have the \Seen flag set.
     Unseen,
+
+    #[cfg(feature = "ext_within")]
+    /// Messages whose internal date is more recent than or equal to the current
+    /// date and time of the server minus the interval, specified in seconds
+    /// [RFC-5032].
+    Younger(NonZeroU32),
 
     #[cfg(feature = "ext_condstore_qresync")]
     ModSequence {

--- a/justfile
+++ b/justfile
@@ -66,7 +66,8 @@ cargo_hack mode: install_cargo_hack
         ext_metadata,\
         ext_namespace,\
         ext_status_size,\
-        ext_utf8 \
+        ext_utf8,\
+        ext_within \
         --group-features \
         quirk_crlf_relaxed,\
         quirk_id_empty_to_nil,\
@@ -98,7 +99,8 @@ cargo_hack mode: install_cargo_hack
         ext_metadata,\
         ext_namespace,\
         ext_status_size,\
-        ext_utf8\
+        ext_utf8,\
+        ext_within\
         {{ mode }}
 	
 [private]


### PR DESCRIPTION
Adds RFC 5032 `WITHIN` support behind the `ext_within` feature gate.