### PR TITLE
docs: list all IMAP extension features

### DIFF
--- a/imap-types/src/lib.rs
+++ b/imap-types/src/lib.rs
@@ -125,6 +125,10 @@
 //! | ext_login_referrals   | IMAP4 Login Referrals ([RFC 2221])                                                                                           | Unfinished |
 //! | ext_mailbox_referrals | IMAP4 Mailbox Referrals ([RFC 2193])                                                                                         | Unfinished |
 //! | ext_metadata          | The IMAP METADATA Extension ([RFC 5464])                                                                                     | Unfinished |
+//! | ext_namespace         | IMAP4 Namespace ([RFC 2342])                                                                                                 |            |
+//! | ext_status_size       | IMAP Extension for STATUS=SIZE ([RFC 8438])                                                                                  |            |
+//! | ext_utf8              | IMAP Support for UTF-8 ([RFC 6855])                                                                                          |            |
+//! | ext_within            | WITHIN Search Extension to the IMAP Protocol ([RFC 5032])                                                                   |            |
 //!
 //! STARTTLS is not an IMAP extension but feature-gated because it [should be avoided](https://nostarttls.secvuln.info/).
 //! For better performance and security, use "implicit TLS", i.e., IMAP-over-TLS on port 993, and don't use STARTTLS at all.
@@ -151,6 +155,7 @@
 //! [RFC 2177]: https://datatracker.ietf.org/doc/html/rfc2177
 //! [RFC 2193]: https://datatracker.ietf.org/doc/html/rfc2193
 //! [RFC 2221]: https://datatracker.ietf.org/doc/html/rfc2221
+//! [RFC 2342]: https://datatracker.ietf.org/doc/html/rfc2342
 //! [RFC 2359]: https://datatracker.ietf.org/doc/html/rfc2359
 //! [RFC 2971]: https://datatracker.ietf.org/doc/html/rfc2971
 //! [RFC 3501]: https://datatracker.ietf.org/doc/html/rfc3501
@@ -159,13 +164,16 @@
 //! [RFC 4315]: https://datatracker.ietf.org/doc/html/rfc4315
 //! [RFC 4959]: https://datatracker.ietf.org/doc/html/rfc4959
 //! [RFC 4978]: https://datatracker.ietf.org/doc/html/rfc4978
+//! [RFC 5032]: https://datatracker.ietf.org/doc/html/rfc5032
 //! [RFC 5161]: https://datatracker.ietf.org/doc/html/rfc5161
 //! [RFC 5256]: https://datatracker.ietf.org/doc/html/rfc5256
 //! [RFC 5464]: https://datatracker.ietf.org/doc/html/rfc5464
 //! [RFC 5957]: https://datatracker.ietf.org/doc/html/rfc5957
 //! [RFC 6851]: https://datatracker.ietf.org/doc/html/rfc6851
+//! [RFC 6855]: https://datatracker.ietf.org/doc/html/rfc6855
 //! [RFC 7162]: https://datatracker.ietf.org/doc/html/rfc7162
 //! [RFC 7888]: https://datatracker.ietf.org/doc/html/rfc7888
+//! [RFC 8438]: https://datatracker.ietf.org/doc/html/rfc8438
 //! [RFC 9208]: https://datatracker.ietf.org/doc/html/rfc9208
 
 // TODO(#660)


### PR DESCRIPTION
## Problem

The crate-level `imap-types` feature table stopped at `ext_metadata`, while `Cargo.toml` also exposes `ext_namespace`, `ext_status_size`, `ext_utf8`, and `ext_within`. Readers therefore could not discover all supported extension gates from the generated crate documentation.

## Fix

- Add the four missing `ext_*` features to the table.
- Link each feature to its defining RFC (2342, 8438, 6855, and 5032).
- Keep the table order aligned with `imap-types/Cargo.toml`.

Closes #727.

## Verification

- `cargo +nightly fmt --all --check`
- `cargo metadata --format-version=1 --no-deps`
- Compared every `ext_*` key in `imap-types/Cargo.toml` with the crate-level table: all 9 are documented, with no missing entries.
- Attempted `cargo doc --no-deps --all-features -p imap-types`; dependency compilation could not start on this Windows host because the system MSVC linker (`link.exe`) is not installed. The manifest and nightly formatting checks complete successfully.

This contribution was prepared with AI assistance and manually reviewed.
